### PR TITLE
Add TR, ATR, and Doji indicators with CLI support

### DIFF
--- a/alpha/app/cli.py
+++ b/alpha/app/cli.py
@@ -6,7 +6,10 @@ import argparse
 import json
 from pathlib import Path
 
+import pandas as pd
+
 from alpha.core.io import read_mt_tsv, to_parquet
+from alpha.core.indicators import atr, is_doji_series, true_range
 from alpha.core.validate import validate_ohlc_frame
 
 
@@ -26,6 +29,52 @@ def analyze_levels_data(data: str, symbol: str, tf: str, tz: str, outdir: str) -
         json.dump(meta, fh, indent=2)
 
 
+def indicators(
+    parquet: str,
+    symbol: str,
+    tf: str,
+    atr_window: int,
+    atr_method: str,
+    doji_body_ratio: float,
+    outdir: str,
+) -> None:
+    """Compute basic indicators and write them to parquet."""
+
+    df = pd.read_parquet(parquet)
+
+    tr = true_range(df)
+    atr_series = atr(df, window=atr_window, method=atr_method)
+    doji = is_doji_series(df, body_ratio=doji_body_ratio)
+
+    out_df = pd.DataFrame(
+        {
+            "tr": tr,
+            f"atr_{atr_method}_{atr_window}": atr_series,
+            "is_doji": doji,
+        }
+    )
+
+    out_path = Path(outdir)
+    out_path.mkdir(parents=True, exist_ok=True)
+    out_df.to_parquet(out_path / "indicators.parquet")
+
+    summary = {
+        "symbol": symbol,
+        "timeframe": tf,
+        "atr_min": float(atr_series.min(skipna=True)),
+        "atr_max": float(atr_series.max(skipna=True)),
+        "atr_mean": float(atr_series.mean(skipna=True)),
+        "doji_count": int(doji.sum()),
+    }
+    with (out_path / "indicators_summary.json").open("w", encoding="utf-8") as fh:
+        json.dump(summary, fh, indent=2)
+
+    print(
+        f"ATR min={summary['atr_min']:.6f} max={summary['atr_max']:.6f} "
+        f"mean={summary['atr_mean']:.6f} | doji={summary['doji_count']}"
+    )
+
+
 # ---- CLI wiring ----
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -38,6 +87,16 @@ def _build_parser() -> argparse.ArgumentParser:
     p.add_argument("--tf", required=True)
     p.add_argument("--tz", required=True)
     p.add_argument("--outdir", required=True)
+
+    p = sub.add_parser("indicators")
+    p.add_argument("--parquet", required=True)
+    p.add_argument("--symbol", required=True)
+    p.add_argument("--tf", required=True)
+    p.add_argument("--atr-window", type=int, default=14)
+    p.add_argument("--atr-method", choices=["ewm", "wilder"], default="ewm")
+    p.add_argument("--doji-body-ratio", type=float, default=0.20)
+    p.add_argument("--outdir", required=True)
+
     return parser
 
 
@@ -50,6 +109,16 @@ def main() -> None:
             symbol=args.symbol,
             tf=args.tf,
             tz=args.tz,
+            outdir=args.outdir,
+        )
+    elif args.command == "indicators":
+        indicators(
+            parquet=args.parquet,
+            symbol=args.symbol,
+            tf=args.tf,
+            atr_window=args.atr_window,
+            atr_method=args.atr_method,
+            doji_body_ratio=args.doji_body_ratio,
             outdir=args.outdir,
         )
     else:

--- a/alpha/core/indicators.py
+++ b/alpha/core/indicators.py
@@ -1,0 +1,88 @@
+import pandas as pd
+import numpy as np
+from typing import Literal
+
+ATRMethod = Literal["ewm", "wilder"]
+
+
+def _ensure_float64(df: pd.DataFrame, cols: list[str]) -> tuple[pd.Series, ...]:
+    """Return requested columns as float64 series."""
+    return tuple(df[c].astype("float64") for c in cols)
+
+
+def true_range(df: pd.DataFrame) -> pd.Series:
+    """Compute the True Range of ``df``.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        DataFrame with ``high``, ``low`` and ``close`` columns.
+
+    Returns
+    -------
+    pd.Series
+        True range values aligned with ``df.index``.
+    """
+    high, low, close = _ensure_float64(df, ["high", "low", "close"])
+    prev_close = close.shift(1)
+
+    tr1 = high - low
+    tr2 = (high - prev_close).abs()
+    tr3 = (low - prev_close).abs()
+
+    tr = np.maximum(tr1, np.maximum(tr2, tr3))
+    tr = tr.fillna(tr1)
+    tr.name = "tr"
+    return tr
+
+
+def atr_ewm(df: pd.DataFrame, window: int = 14) -> pd.Series:
+    """Average True Range using exponential weighting.
+
+    ``alpha`` is set to ``1 / window`` and ``adjust=False``.
+    """
+    tr = true_range(df)
+    atr = tr.ewm(alpha=1.0 / float(window), adjust=False).mean()
+    atr.name = f"atr_ewm_{window}"
+    return atr
+
+
+def atr_wilder(df: pd.DataFrame, window: int = 14) -> pd.Series:
+    """Average True Range using Wilder's smoothing."""
+    tr = true_range(df).to_numpy(dtype="float64")
+    atr = np.full_like(tr, np.nan, dtype="float64")
+
+    if len(tr) >= window:
+        atr[window - 1] = tr[:window].mean()
+        for i in range(window, len(tr)):
+            atr[i] = (atr[i - 1] * (window - 1) + tr[i]) / window
+
+    out = pd.Series(atr, index=df.index, name=f"atr_wilder_{window}")
+    return out
+
+
+def is_doji_row(o: float, h: float, lo: float, c: float, body_ratio: float = 0.20) -> bool:
+    """Detect a doji candlestick for a single row."""
+    eps = 1e-12
+    body = abs(c - o)
+    rng = max(h - lo, eps)
+    return body <= body_ratio * rng
+
+
+def is_doji_series(df: pd.DataFrame, body_ratio: float = 0.20) -> pd.Series:
+    """Vectorised doji detection for a dataframe."""
+    o, h, lo, c = _ensure_float64(df, ["open", "high", "low", "close"])
+    eps = 1e-12
+    body = (c - o).abs()
+    rng = np.maximum(h - lo, eps)
+    doji = body <= body_ratio * rng
+    return pd.Series(doji, index=df.index, name="is_doji", dtype="bool")
+
+
+def atr(df: pd.DataFrame, window: int = 14, method: ATRMethod = "ewm") -> pd.Series:
+    """Wrapper for ATR calculation selecting the smoothing method."""
+    if method == "ewm":
+        return atr_ewm(df, window)
+    if method == "wilder":
+        return atr_wilder(df, window)
+    raise ValueError("Unknown ATR method")

--- a/tests/test_indicators.py
+++ b/tests/test_indicators.py
@@ -1,0 +1,111 @@
+from pathlib import Path
+import sys
+
+# Ensure project root on path when running via `uv run`
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import pandas as pd
+
+from alpha.core.indicators import atr, atr_ewm, atr_wilder, is_doji_series, true_range
+from alpha.app.cli import analyze_levels_data, indicators
+
+
+def _sample_df() -> pd.DataFrame:
+    idx = pd.date_range("2020-01-01", periods=4, freq="D", tz="UTC")
+    df = pd.DataFrame(
+        {
+            "open": [10.0, 12.0, 18.0, 15.0],
+            "high": [15.0, 16.0, 20.0, 18.0],
+            "low": [9.0, 11.0, 17.0, 14.0],
+            "close": [12.0, 15.0, 18.0, 16.0],
+        },
+        index=idx,
+    )
+    return df
+
+
+def test_true_range_and_doji_basic():
+    df = _sample_df()
+    tr = true_range(df)
+    expected = pd.Series([6.0, 5.0, 5.0, 4.0], index=df.index, name="tr")
+    pd.testing.assert_series_equal(tr, expected)
+
+    # Doji detection
+    df_doji = pd.DataFrame(
+        {
+            "open": [1.0, 1.0, 1.0],
+            "high": [1.0, 2.0, 1.0],
+            "low": [1.0, 0.0, 1.0],
+            "close": [1.0, 1.5, 1.0],
+        },
+        index=pd.date_range("2020", periods=3, freq="D", tz="UTC"),
+    )
+    is_doji = is_doji_series(df_doji, body_ratio=0.2)
+    expected_doji = pd.Series([True, False, True], index=df_doji.index, name="is_doji")
+    pd.testing.assert_series_equal(is_doji, expected_doji)
+
+
+def test_atr_methods_unit():
+    df = _sample_df()
+    atr_e = atr_ewm(df, window=3)
+    atr_w = atr_wilder(df, window=3)
+    assert atr_e.notna().all()
+    assert atr_e.gt(0).all()
+    assert atr_w.isna().sum() == 2
+    assert atr_w.dropna().gt(0).all()
+
+
+def test_true_range_edge_cases():
+    idx = pd.date_range("2021", periods=2, freq="D", tz="UTC")
+    df = pd.DataFrame(
+        {
+            "high": [1.0, 5.0],
+            "low": [1.0, 4.0],
+            "close": [1.0, 4.0],
+        },
+        index=idx,
+    )
+    tr = true_range(df)
+    assert tr.iloc[0] == 0.0
+    assert tr.iloc[1] == 4.0
+
+
+def test_indicators_integration(tmp_path):
+    outdir = tmp_path / "data"
+    analyze_levels_data(
+        data="data/EURUSD_H1.tsv",
+        symbol="EURUSD",
+        tf="H1",
+        tz="UTC",
+        outdir=str(outdir),
+    )
+    df = pd.read_parquet(outdir / "ohlc.parquet")
+    # replicate data to have enough rows for ATR window
+    df = pd.concat([df] * 3)
+    df.index = pd.date_range(df.index[0], periods=len(df), freq="h", tz="UTC")
+    big_path = outdir / "ohlc_big.parquet"
+    df.to_parquet(big_path)
+
+    atr_e = atr(df, 14, method="ewm")
+    atr_w = atr(df, 14, method="wilder")
+    assert atr_e.notna().all()
+    assert atr_e.gt(0).all()
+    assert atr_w.isna().sum() == 13
+    assert atr_w.dropna().gt(0).all()
+    tail = int(len(df) * 0.3)
+    assert atr_e.iloc[-tail:].corr(atr_w.iloc[-tail:]) > 0.98
+
+    feat_dir = tmp_path / "feat"
+    indicators(
+        parquet=str(big_path),
+        symbol="EURUSD",
+        tf="H1",
+        atr_window=14,
+        atr_method="ewm",
+        doji_body_ratio=0.2,
+        outdir=str(feat_dir),
+    )
+    path = feat_dir / "indicators.parquet"
+    assert path.exists()
+    res = pd.read_parquet(path)
+    assert {"tr", "atr_ewm_14", "is_doji"}.issubset(res.columns)


### PR DESCRIPTION
## Summary
- implement true range and ATR indicators (EWMA and Wilder)
- add doji detection for rows and series
- expose indicators via new `indicators` CLI command
- add unit and integration tests for indicators

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad479018988324a2e193d44b81c3a1