### PR TITLE
Add two-close level formation detector and CLI

### DIFF
--- a/alpha/core/indicators.py
+++ b/alpha/core/indicators.py
@@ -4,6 +4,16 @@ from typing import Literal
 
 ATRMethod = Literal["ewm", "wilder"]
 
+__all__ = [
+    "ATRMethod",
+    "true_range",
+    "atr_ewm",
+    "atr_wilder",
+    "is_doji_row",
+    "is_doji_series",
+    "atr",
+]
+
 
 def _ensure_float64(df: pd.DataFrame, cols: list[str]) -> tuple[pd.Series, ...]:
     """Return requested columns as float64 series."""

--- a/alpha/levels/detector.py
+++ b/alpha/levels/detector.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal, Optional
+
+import pandas as pd
+
+from alpha.core.indicators import is_doji_series
+
+LevelType = Literal["peak", "trough"]
+
+
+@dataclass
+class LevelsCfgFormation:
+    doji_body_ratio: float = 0.20
+    ignore_doji: bool = True
+    cooldown_bars: int = 0
+    min_leg_body_ratio: float = 0.0
+    tick_size: float = 0.0
+
+
+def _cooldown_ok(current_idx: int, last_end_idx: Optional[int], cooldown: int) -> bool:
+    if cooldown <= 0:
+        return True
+    if last_end_idx is None:
+        return True
+    return current_idx - last_end_idx >= cooldown
+
+
+def detect_levels_formation(df: pd.DataFrame, cfg: LevelsCfgFormation) -> pd.DataFrame:
+    """Detect peak/trough levels via two-close formation."""
+    required = {"open", "high", "low", "close"}
+    if not required.issubset(df.columns):  # pragma: no cover - sanity check
+        raise ValueError("df must contain open, high, low, close columns")
+
+    doji = (
+        is_doji_series(df, body_ratio=cfg.doji_body_ratio)
+        if cfg.ignore_doji
+        else pd.Series(False, index=df.index)
+    )
+
+    levels: list[dict[str, object]] = []
+    last_end_idx: Optional[int] = None
+    eps = 1e-12
+
+    for i in range(1, len(df)):
+        o1, h1, l1, c1 = df.iloc[i - 1][["open", "high", "low", "close"]]
+        o2, h2, l2, c2 = df.iloc[i][["open", "high", "low", "close"]]
+
+        if cfg.ignore_doji and (doji.iat[i - 1] or doji.iat[i]):
+            continue
+
+        if cfg.min_leg_body_ratio > 0:
+            r1 = max(h1 - l1, eps)
+            r2 = max(h2 - l2, eps)
+            if abs(c1 - o1) < cfg.min_leg_body_ratio * r1:
+                continue
+            if abs(c2 - o2) < cfg.min_leg_body_ratio * r2:
+                continue
+
+        dir1 = 1 if c1 > o1 else (-1 if c1 < o1 else 0)
+        dir2 = 1 if c2 > o2 else (-1 if c2 < o2 else 0)
+
+        if dir1 == -1 and dir2 == -1 and c2 < c1:
+            if not _cooldown_ok(i, last_end_idx, cfg.cooldown_bars):
+                continue
+            price = max(h1, h2)
+            if cfg.tick_size > 0:
+                price = round(price / cfg.tick_size) * cfg.tick_size
+            levels.append(
+                {
+                    "time": df.index[i],
+                    "type": "peak",
+                    "price": float(price),
+                    "start_idx": i - 1,
+                    "end_idx": i,
+                    "source_closes": "bear,bear",
+                    "notes": "",
+                }
+            )
+            last_end_idx = i
+        elif dir1 == 1 and dir2 == 1 and c2 > c1:
+            if not _cooldown_ok(i, last_end_idx, cfg.cooldown_bars):
+                continue
+            price = min(l1, l2)
+            if cfg.tick_size > 0:
+                price = round(price / cfg.tick_size) * cfg.tick_size
+            levels.append(
+                {
+                    "time": df.index[i],
+                    "type": "trough",
+                    "price": float(price),
+                    "start_idx": i - 1,
+                    "end_idx": i,
+                    "source_closes": "bull,bull",
+                    "notes": "",
+                }
+            )
+            last_end_idx = i
+
+    return pd.DataFrame(
+        levels,
+        columns=[
+            "time",
+            "type",
+            "price",
+            "start_idx",
+            "end_idx",
+            "source_closes",
+            "notes",
+        ],
+    )

--- a/tests/test_levels_formation.py
+++ b/tests/test_levels_formation.py
@@ -1,0 +1,143 @@
+from pathlib import Path
+from pathlib import Path
+import sys
+import json
+
+import pandas as pd
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from alpha.levels.detector import LevelsCfgFormation, detect_levels_formation
+from alpha.app.cli import analyze_levels_data, analyze_levels_formation
+
+
+def _bearish_df(n: int = 4) -> pd.DataFrame:
+    idx = pd.date_range("2020", periods=n, freq="H", tz="UTC")
+    opens = [10 - i for i in range(n)]
+    closes = [o - 1 for o in opens]
+    highs = [o + 0.5 for o in opens]
+    lows = [c - 0.5 for c in closes]
+    return pd.DataFrame({"open": opens, "high": highs, "low": lows, "close": closes}, index=idx)
+
+
+def _bullish_df(n: int = 4) -> pd.DataFrame:
+    idx = pd.date_range("2020", periods=n, freq="H", tz="UTC")
+    opens = [10 + i for i in range(n)]
+    closes = [o + 1 for o in opens]
+    highs = [c + 0.5 for c in closes]
+    lows = [o - 0.5 for o in opens]
+    return pd.DataFrame({"open": opens, "high": highs, "low": lows, "close": closes}, index=idx)
+
+
+def test_downtrend_produces_peaks():
+    df = _bearish_df(4)
+    res = detect_levels_formation(df, LevelsCfgFormation())
+    assert len(res) == 3
+    assert (res["type"] == "peak").all()
+    assert res["price"].tolist() == [10.5, 9.5, 8.5]
+    assert res["start_idx"].tolist() == [0, 1, 2]
+    assert res["end_idx"].tolist() == [1, 2, 3]
+
+
+def test_uptrend_produces_troughs():
+    df = _bullish_df(4)
+    res = detect_levels_formation(df, LevelsCfgFormation())
+    assert len(res) == 3
+    assert (res["type"] == "trough").all()
+    assert res["price"].tolist() == [9.5, 10.5, 11.5]
+
+
+def test_ignore_doji():
+    idx = pd.date_range("2021", periods=2, freq="H", tz="UTC")
+    df = pd.DataFrame(
+        {
+            "open": [1.0, 1.02],
+            "high": [1.1, 1.3],
+            "low": [0.9, 1.0],
+            "close": [1.02, 1.2],
+        },
+        index=idx,
+    )
+    res = detect_levels_formation(df, LevelsCfgFormation())
+    assert res.empty
+    res2 = detect_levels_formation(df, LevelsCfgFormation(ignore_doji=False))
+    assert len(res2) == 1
+    assert res2.iloc[0]["type"] == "trough"
+    assert pytest.approx(res2.iloc[0]["price"], rel=1e-6) == 0.9
+
+
+def test_min_leg_body_ratio():
+    idx = pd.date_range("2022", periods=2, freq="H", tz="UTC")
+    df = pd.DataFrame(
+        {
+            "open": [1.0, 1.1],
+            "high": [1.2, 1.4],
+            "low": [0.8, 1.0],
+            "close": [1.05, 1.3],
+        },
+        index=idx,
+    )
+    res = detect_levels_formation(df, LevelsCfgFormation(min_leg_body_ratio=0.5, ignore_doji=False))
+    assert res.empty
+
+
+def test_cooldown_bars():
+    df = _bearish_df(5)
+    cfg = LevelsCfgFormation(cooldown_bars=2)
+    res = detect_levels_formation(df, cfg)
+    assert len(res) == 2
+    assert (res["end_idx"].diff().dropna() >= 2).all()
+
+
+def test_tick_size_rounding():
+    idx = pd.date_range("2023", periods=2, freq="H", tz="UTC")
+    df = pd.DataFrame(
+        {
+            "open": [1.0, 1.4],
+            "high": [1.5, 1.8],
+            "low": [1.23, 1.26],
+            "close": [1.4, 1.7],
+        },
+        index=idx,
+    )
+    res = detect_levels_formation(df, LevelsCfgFormation(tick_size=0.1))
+    assert len(res) == 1
+    assert res.iloc[0]["price"] == pytest.approx(1.2)
+
+
+def test_integration_levels_formation(tmp_path):
+    data_dir = tmp_path / "data"
+    analyze_levels_data(
+        data="data/EURUSD_H1.tsv",
+        symbol="EURUSD",
+        tf="H1",
+        tz="UTC",
+        outdir=str(data_dir),
+    )
+    parquet_path = data_dir / "ohlc.parquet"
+    outdir = tmp_path / "levels"
+    analyze_levels_formation(
+        parquet=str(parquet_path),
+        symbol="EURUSD",
+        tf="H1",
+        profile="h1",
+        outdir=str(outdir),
+    )
+
+    csv_path = outdir / "levels_formation.csv"
+    assert csv_path.exists()
+    levels = pd.read_csv(csv_path, parse_dates=["time"])
+    assert {"time", "type", "price", "start_idx", "end_idx", "source_closes", "notes"}.issubset(
+        levels.columns
+    )
+    assert len(levels) > 0
+    assert levels["type"].isin(["peak", "trough"]).all()
+    assert not levels["price"].isna().any()
+
+    summary_path = outdir / "levels_formation_summary.json"
+    with summary_path.open("r", encoding="utf-8") as fh:
+        summary = json.load(fh)
+    assert summary["n_bars"] > 0
+    assert summary["n_levels"] == len(levels)
+    assert summary["density_per_1000"] > 0


### PR DESCRIPTION
## Summary
- implement `LevelsCfgFormation` and `detect_levels_formation` for two-close peak/trough detection with doji filtering, cooldown, body ratio and tick rounding
- expose indicator helpers via `__all__` and add `analyze-levels-formation` CLI command
- add comprehensive unit and integration tests for level formation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad4b7f9a008324a48b59ad9fcd74ee