### PR TITLE
feat: track dynamic level break and updates

### DIFF
--- a/alpha/config/levels.yml
+++ b/alpha/config/levels.yml
@@ -4,13 +4,37 @@ profiles:
     proportionality_ratio: 0.50
     prop_ref_mode: "prev_leg_or_atr"
     atr_window: 14
+    break_confirm:
+      mode: "atr"
+      atr_mult: 0.15
+      pips: 15
+    update_on_wick: true
+    max_update_distance_atr_mult: 2.0
+    tick_size: 0.0
+    pip_size: 0.0001
   m15:
     tz: "UTC"
     proportionality_ratio: 0.50
     prop_ref_mode: "prev_leg_or_atr"
     atr_window: 14
+    break_confirm:
+      mode: "atr"
+      atr_mult: 0.15
+      pips: 15
+    update_on_wick: true
+    max_update_distance_atr_mult: 2.0
+    tick_size: 0.0
+    pip_size: 0.0001
   m1:
     tz: "UTC"
     proportionality_ratio: 0.60
     prop_ref_mode: "prev_leg_or_atr"
     atr_window: 14
+    break_confirm:
+      mode: "atr"
+      atr_mult: 0.15
+      pips: 15
+    update_on_wick: true
+    max_update_distance_atr_mult: 2.0
+    tick_size: 0.0
+    pip_size: 0.0001

--- a/alpha/levels/break_update.py
+++ b/alpha/levels/break_update.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+import pandas as pd
+
+from alpha.core.indicators import atr
+
+BreakMode = Literal["atr", "pips"]
+
+
+@dataclass
+class LevelsCfgBreakUpdate:
+    break_mode: BreakMode = "atr"
+    atr_mult: float = 0.15
+    pips: float = 10.0
+    update_on_wick: bool = True
+    max_update_distance_atr_mult: float = 2.0
+    tick_size: float = 0.0
+    pip_size: float = 0.0001
+    atr_window: int = 14
+
+
+def apply_break_update(
+    df: pd.DataFrame,
+    levels_df: pd.DataFrame,
+    cfg: LevelsCfgBreakUpdate,
+) -> pd.DataFrame:
+    """Determine break/update state for each level.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        OHLC dataframe with a ``DatetimeIndex``.
+    levels_df : pd.DataFrame
+        Levels dataframe from formation/proportionality step.
+    cfg : LevelsCfgBreakUpdate
+        Configuration for break/update logic.
+
+    Returns
+    -------
+    pd.DataFrame
+        ``levels_df`` with additional state columns.
+    """
+
+    required = {"open", "high", "low", "close"}
+    if not required.issubset(df.columns):  # pragma: no cover - sanity check
+        raise ValueError("df must contain open, high, low, close columns")
+
+    levels = levels_df.copy().reset_index(drop=True)
+    n = len(df)
+    atr_series = atr(df, window=cfg.atr_window)
+    eps = 1e-12
+
+    # initialise new columns
+    levels["state"] = "intact"
+    levels["break_time"] = pd.Series(pd.NaT, index=levels.index, dtype="datetime64[ns, UTC]")
+    levels["break_idx"] = -1
+    levels["last_extreme"] = levels["price"].astype(float)
+    levels["update_count"] = 0
+    levels["touch_count"] = 0
+    levels["first_touch_time"] = pd.Series(
+        pd.NaT, index=levels.index, dtype="datetime64[ns, UTC]"
+    )
+    levels["confirm_threshold"] = 0.0
+    levels["break_mode"] = cfg.break_mode
+    levels["tick_size"] = cfg.tick_size
+
+    for idx, row in levels.iterrows():
+        price = float(row["price"])
+        last_extreme = price
+        update_count = 0
+        touch_count = 0
+        first_touch_time = pd.NaT
+        state = "intact"
+        break_idx = -1
+        break_time = pd.NaT
+
+        end_idx = int(row["end_idx"])
+        start_scan = end_idx + 1
+        if start_scan < n:
+            atr_j = float(atr_series.iat[start_scan])
+        else:
+            atr_j = float(atr_series.iat[end_idx])
+        atr_j = max(atr_j, eps)
+        confirm_thr = (
+            atr_j * cfg.atr_mult
+            if cfg.break_mode == "atr"
+            else cfg.pips * cfg.pip_size
+        )
+
+        for j in range(start_scan, n):
+            atr_j = max(float(atr_series.iat[j]), eps)
+            thr = (
+                atr_j * cfg.atr_mult
+                if cfg.break_mode == "atr"
+                else cfg.pips * cfg.pip_size
+            )
+            confirm_thr = thr
+
+            close_j = float(df["close"].iat[j])
+            high_j = float(df["high"].iat[j])
+            low_j = float(df["low"].iat[j])
+
+            if row["type"] == "peak":
+                if close_j > price + thr:
+                    state = "broken"
+                    break_idx = j
+                    break_time = df.index[j]
+                    if cfg.tick_size > 0:
+                        price = round(price / cfg.tick_size) * cfg.tick_size
+                    break
+                if cfg.update_on_wick and high_j >= price and close_j <= price + thr:
+                    if touch_count == 0:
+                        first_touch_time = df.index[j]
+                    touch_count += 1
+                    new_price = max(last_extreme, high_j)
+                    if abs(new_price - price) <= atr_j * cfg.max_update_distance_atr_mult:
+                        price = last_extreme = new_price
+                        update_count += 1
+                        if cfg.tick_size > 0:
+                            price = last_extreme = round(
+                                price / cfg.tick_size
+                            ) * cfg.tick_size
+            else:  # trough
+                if close_j < price - thr:
+                    state = "broken"
+                    break_idx = j
+                    break_time = df.index[j]
+                    if cfg.tick_size > 0:
+                        price = round(price / cfg.tick_size) * cfg.tick_size
+                    break
+                if cfg.update_on_wick and low_j <= price and close_j >= price - thr:
+                    if touch_count == 0:
+                        first_touch_time = df.index[j]
+                    touch_count += 1
+                    new_price = min(last_extreme, low_j)
+                    if abs(new_price - price) <= atr_j * cfg.max_update_distance_atr_mult:
+                        price = last_extreme = new_price
+                        update_count += 1
+                        if cfg.tick_size > 0:
+                            price = last_extreme = round(
+                                price / cfg.tick_size
+                            ) * cfg.tick_size
+
+        levels.at[idx, "price"] = price
+        levels.at[idx, "state"] = state
+        levels.at[idx, "break_idx"] = break_idx
+        levels.at[idx, "break_time"] = break_time
+        levels.at[idx, "last_extreme"] = last_extreme
+        levels.at[idx, "update_count"] = update_count
+        levels.at[idx, "touch_count"] = touch_count
+        levels.at[idx, "first_touch_time"] = first_touch_time
+        levels.at[idx, "confirm_threshold"] = confirm_thr
+        levels.at[idx, "break_mode"] = cfg.break_mode
+        levels.at[idx, "tick_size"] = cfg.tick_size
+
+    return levels

--- a/tests/test_levels_break.py
+++ b/tests/test_levels_break.py
@@ -1,0 +1,208 @@
+from pathlib import Path
+import sys
+
+import pandas as pd
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from alpha.core.indicators import atr
+from alpha.levels.break_update import LevelsCfgBreakUpdate, apply_break_update
+from alpha.app.cli import (
+    analyze_levels_data,
+    analyze_levels_formation,
+    analyze_levels_prop,
+    analyze_levels_break,
+)
+
+
+def test_break_body_peak():
+    idx = pd.date_range("2020", periods=2, freq="h", tz="UTC")
+    df = pd.DataFrame(
+        {
+            "open": [0.5, 0.5],
+            "high": [1.0, 1.5],
+            "low": [0.0, 0.0],
+            "close": [0.5, 1.2],
+        },
+        index=idx,
+    )
+    levels = pd.DataFrame(
+        [{"time": idx[0], "type": "peak", "price": 0.5, "start_idx": 0, "end_idx": 0}]
+    )
+    cfg = LevelsCfgBreakUpdate(break_mode="atr", atr_mult=0.5)
+    res = apply_break_update(df, levels, cfg)
+    assert res.loc[0, "state"] == "broken"
+    assert res.loc[0, "break_idx"] == 1
+    thr_expected = atr(df).iloc[1] * 0.5
+    assert res.loc[0, "confirm_threshold"] == pytest.approx(thr_expected)
+
+
+def test_wick_update_peak():
+    idx = pd.date_range("2020", periods=2, freq="h", tz="UTC")
+    df = pd.DataFrame(
+        {
+            "open": [0.5, 0.5],
+            "high": [1.0, 1.0],
+            "low": [0.0, 0.0],
+            "close": [0.5, 0.6],
+        },
+        index=idx,
+    )
+    levels = pd.DataFrame(
+        [{"time": idx[0], "type": "peak", "price": 0.5, "start_idx": 0, "end_idx": 0}]
+    )
+    cfg = LevelsCfgBreakUpdate(break_mode="atr", atr_mult=0.5)
+    res = apply_break_update(df, levels, cfg)
+    assert res.loc[0, "state"] == "intact"
+    assert res.loc[0, "update_count"] == 1
+    assert res.loc[0, "touch_count"] == 1
+    assert res.loc[0, "price"] == pytest.approx(1.0)
+    assert pd.notna(res.loc[0, "first_touch_time"])
+
+
+def test_break_body_trough():
+    idx = pd.date_range("2020", periods=2, freq="h", tz="UTC")
+    df = pd.DataFrame(
+        {
+            "open": [0.5, 0.5],
+            "high": [1.0, 0.5],
+            "low": [0.0, -0.5],
+            "close": [0.5, -0.2],
+        },
+        index=idx,
+    )
+    levels = pd.DataFrame(
+        [{"time": idx[0], "type": "trough", "price": 0.5, "start_idx": 0, "end_idx": 0}]
+    )
+    cfg = LevelsCfgBreakUpdate(break_mode="atr", atr_mult=0.5)
+    res = apply_break_update(df, levels, cfg)
+    assert res.loc[0, "state"] == "broken"
+    assert res.loc[0, "break_idx"] == 1
+
+
+def test_wick_update_trough():
+    idx = pd.date_range("2020", periods=2, freq="h", tz="UTC")
+    df = pd.DataFrame(
+        {
+            "open": [0.5, 0.5],
+            "high": [1.0, 1.0],
+            "low": [0.0, 0.0],
+            "close": [0.5, 0.4],
+        },
+        index=idx,
+    )
+    levels = pd.DataFrame(
+        [{"time": idx[0], "type": "trough", "price": 0.5, "start_idx": 0, "end_idx": 0}]
+    )
+    cfg = LevelsCfgBreakUpdate(break_mode="atr", atr_mult=0.5)
+    res = apply_break_update(df, levels, cfg)
+    assert res.loc[0, "state"] == "intact"
+    assert res.loc[0, "update_count"] == 1
+    assert res.loc[0, "touch_count"] == 1
+    assert res.loc[0, "price"] == pytest.approx(0.0)
+    assert pd.notna(res.loc[0, "first_touch_time"])
+
+
+def test_update_limit():
+    idx = pd.date_range("2020", periods=2, freq="h", tz="UTC")
+    df = pd.DataFrame(
+        {
+            "open": [0.5, 0.5],
+            "high": [1.0, 2.0],
+            "low": [0.0, 0.0],
+            "close": [0.5, 0.6],
+        },
+        index=idx,
+    )
+    levels = pd.DataFrame(
+        [{"time": idx[0], "type": "peak", "price": 0.5, "start_idx": 0, "end_idx": 0}]
+    )
+    cfg = LevelsCfgBreakUpdate(
+        break_mode="atr", atr_mult=0.5, max_update_distance_atr_mult=0.5
+    )
+    res = apply_break_update(df, levels, cfg)
+    assert res.loc[0, "price"] == pytest.approx(0.5)
+    assert res.loc[0, "update_count"] == 0
+    assert res.loc[0, "touch_count"] == 1
+
+
+def test_mode_pips_threshold():
+    idx = pd.date_range("2020", periods=2, freq="h", tz="UTC")
+    df = pd.DataFrame(
+        {
+            "open": [1.0, 1.0],
+            "high": [1.005, 1.005],
+            "low": [0.995, 0.995],
+            "close": [1.0, 1.002],
+        },
+        index=idx,
+    )
+    levels = pd.DataFrame(
+        [{"time": idx[0], "type": "peak", "price": 1.0, "start_idx": 0, "end_idx": 0}]
+    )
+    cfg = LevelsCfgBreakUpdate(break_mode="pips", pips=10, pip_size=0.0001)
+    res = apply_break_update(df, levels, cfg)
+    assert res.loc[0, "state"] == "broken"
+    assert res.loc[0, "break_idx"] == 1
+    assert res.loc[0, "confirm_threshold"] == pytest.approx(0.001)
+
+
+def test_integration_levels_break(tmp_path):
+    data_dir = tmp_path / "data"
+    analyze_levels_data(
+        data="data/EURUSD_H1.tsv",
+        symbol="EURUSD",
+        tf="H1",
+        tz="UTC",
+        outdir=str(data_dir),
+    )
+    parquet_path = data_dir / "ohlc.parquet"
+    levels_dir = tmp_path / "levels"
+    analyze_levels_formation(
+        parquet=str(parquet_path),
+        symbol="EURUSD",
+        tf="H1",
+        profile="h1",
+        outdir=str(levels_dir),
+    )
+    levels_csv = levels_dir / "levels_formation.csv"
+    prop_dir = tmp_path / "prop"
+    analyze_levels_prop(
+        parquet=str(parquet_path),
+        levels_csv=str(levels_csv),
+        symbol="EURUSD",
+        tf="H1",
+        profile="h1",
+        outdir=str(prop_dir),
+    )
+    levels_prop_csv = prop_dir / "levels_prop.csv"
+    outdir = tmp_path / "break"
+    analyze_levels_break(
+        parquet=str(parquet_path),
+        levels_csv=str(levels_prop_csv),
+        symbol="EURUSD",
+        tf="H1",
+        profile="h1",
+        outdir=str(outdir),
+    )
+    csv_path = outdir / "levels_state.csv"
+    assert csv_path.exists()
+    state_df = pd.read_csv(csv_path, parse_dates=["time", "break_time", "first_touch_time"])
+    required = {
+        "state",
+        "break_time",
+        "break_idx",
+        "last_extreme",
+        "update_count",
+        "touch_count",
+        "first_touch_time",
+        "confirm_threshold",
+        "break_mode",
+        "tick_size",
+    }
+    assert required.issubset(state_df.columns)
+    non_null_cols = required - {"break_time", "first_touch_time"}
+    assert not state_df[list(non_null_cols)].isna().any().any()
+    share_broken = state_df["state"].eq("broken").mean()
+    assert 0.0 <= share_broken <= 1.0


### PR DESCRIPTION
## Summary
- add break/update algorithm for levels with ATR or pip thresholds
- expose `analyze-levels-break` CLI to produce `levels_state.csv`
- extend levels config with break confirmation and update controls

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad5096981883249ff8a2ea26078b7c