### PR TITLE
feat: build swings from levels

### DIFF
--- a/alpha/structure/swings.py
+++ b/alpha/structure/swings.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+"""Utilities to build price swings from processed levels."""
+
+from dataclasses import dataclass, asdict
+from typing import List, Literal
+
+import pandas as pd
+
+from alpha.core.indicators import atr
+
+SwingType = Literal["peak", "trough"]
+
+
+@dataclass
+class SwingsCfg:
+    """Configuration for swing construction."""
+
+    use_only_strong_swings: bool = True
+    swing_merge_atr_mult: float = 0.10
+    min_gap_bars: int = 1
+    min_price_delta_atr_mult: float = 0.05
+    keep_latest_on_tie: bool = True
+    atr_window: int = 14
+
+
+def _ensure_level_ids(levels: pd.DataFrame) -> pd.DataFrame:
+    if "level_id" not in levels.columns:
+        levels = levels.copy()
+        levels["level_id"] = range(len(levels))
+    return levels
+
+
+def build_swings(df: pd.DataFrame, levels_df: pd.DataFrame, cfg: SwingsCfg) -> pd.DataFrame:
+    """Build swings from level dataframe following provided configuration."""
+
+    levels_df = _ensure_level_ids(levels_df)
+    levels_df = levels_df.sort_values("end_idx").reset_index(drop=True)
+
+    # initial filtering
+    if cfg.use_only_strong_swings and "weak_prop" in levels_df.columns:
+        levels_df = levels_df[~levels_df["weak_prop"].astype(bool)].copy()
+
+    cols = [c for c in ["time", "end_idx", "type", "price", "weak_prop", "level_id"] if c in levels_df.columns]
+    levels = levels_df[cols].copy()
+
+    atr_series = atr(df, window=cfg.atr_window)
+    eps = 1e-12
+
+    swings: List[dict] = []
+    merge_same = 0
+
+    for _, row in levels.iterrows():
+        swing = {
+            "time": row["time"],
+            "idx": int(row["end_idx"]),
+            "type": row["type"],
+            "price": float(row["price"]),
+            "src_level_ids": [row["level_id"]],
+            "merged_count": 1,
+            "weak_any": bool(row.get("weak_prop", False)),
+        }
+        if not swings:
+            swings.append(swing)
+            continue
+        last = swings[-1]
+        if swing["type"] == last["type"]:
+            merge_same += 1
+            if swing["type"] == "peak":
+                better = swing["price"] > last["price"] or (
+                    abs(swing["price"] - last["price"]) <= eps and cfg.keep_latest_on_tie
+                )
+            else:  # trough
+                better = swing["price"] < last["price"] or (
+                    abs(swing["price"] - last["price"]) <= eps and cfg.keep_latest_on_tie
+                )
+            if better:
+                swing["src_level_ids"] = last["src_level_ids"] + swing["src_level_ids"]
+                swing["merged_count"] = last["merged_count"] + swing["merged_count"]
+                swing["weak_any"] = last["weak_any"] or swing["weak_any"]
+                swings[-1] = swing
+            else:
+                last["src_level_ids"].extend(swing["src_level_ids"])
+                last["merged_count"] += swing["merged_count"]
+                last["weak_any"] = last["weak_any"] or swing["weak_any"]
+        else:
+            swings.append(swing)
+
+    # merge nearby swings
+    merge_near = 0
+    i = 1
+    while i < len(swings):
+        prev = swings[i - 1]
+        cur = swings[i]
+        gap = cur["idx"] - prev["idx"]
+        price_delta = abs(cur["price"] - prev["price"])
+        atr_ref = float(atr_series.iloc[cur["idx"]]) if len(atr_series) > cur["idx"] else 0.0
+        if atr_ref < eps:
+            atr_ref = eps
+        cond = False
+        if price_delta <= atr_ref * cfg.swing_merge_atr_mult + eps:
+            cond = True
+        if gap < cfg.min_gap_bars:
+            cond = True
+        if price_delta <= atr_ref * cfg.min_price_delta_atr_mult + eps:
+            cond = True
+        if cond:
+            merge_near += 1
+            if cur["type"] == "peak":
+                better = cur["price"] > prev["price"] or (
+                    abs(cur["price"] - prev["price"]) <= eps and cfg.keep_latest_on_tie
+                )
+            else:
+                better = cur["price"] < prev["price"] or (
+                    abs(cur["price"] - prev["price"]) <= eps and cfg.keep_latest_on_tie
+                )
+            if better:
+                cur["src_level_ids"] = prev["src_level_ids"] + cur["src_level_ids"]
+                cur["merged_count"] = prev["merged_count"] + cur["merged_count"]
+                cur["weak_any"] = prev["weak_any"] or cur["weak_any"]
+                swings[i - 1] = cur
+                swings.pop(i)
+            else:
+                prev["src_level_ids"].extend(cur["src_level_ids"])
+                prev["merged_count"] += cur["merged_count"]
+                prev["weak_any"] = prev["weak_any"] or cur["weak_any"]
+                swings.pop(i)
+        else:
+            i += 1
+
+    # compute helper fields
+    for k, sw in enumerate(swings):
+        sw["swing_id"] = k
+        sw["src_level_ids"] = ",".join(map(str, sw["src_level_ids"]))
+        sw["gap_from_prev"] = (
+            sw["idx"] - swings[k - 1]["idx"] if k > 0 else pd.NA
+        )
+        sw["leg_from_prev"] = (
+            abs(sw["price"] - swings[k - 1]["price"]) if k > 0 else float("nan")
+        )
+        sw["leg_to_next"] = (
+            abs(swings[k + 1]["price"] - sw["price"]) if k < len(swings) - 1 else float("nan")
+        )
+        sw["atr_at_idx"] = (
+            float(atr_series.iloc[sw["idx"]]) if len(atr_series) > sw["idx"] else float("nan")
+        )
+
+    out_cols = [
+        "swing_id",
+        "time",
+        "idx",
+        "type",
+        "price",
+        "src_level_ids",
+        "merged_count",
+        "weak_any",
+        "gap_from_prev",
+        "leg_from_prev",
+        "leg_to_next",
+        "atr_at_idx",
+    ]
+    out_df = pd.DataFrame(swings, columns=out_cols)
+    out_df.attrs["merge_same_type_count"] = merge_same
+    out_df.attrs["merge_nearby_count"] = merge_near
+    return out_df
+
+
+def summarize_swings(swings_df: pd.DataFrame, levels_df: pd.DataFrame, cfg: SwingsCfg) -> dict:
+    """Produce summary statistics for swings."""
+
+    n_levels_in = int(len(levels_df))
+    n_levels_used = int(swings_df["merged_count"].sum()) if len(swings_df) else 0
+    n_swings = int(len(swings_df))
+    weak_ratio_in = (
+        float(levels_df.get("weak_prop", pd.Series(dtype="float64")).mean())
+        if ("weak_prop" in levels_df.columns and len(levels_df))
+        else 0.0
+    )
+    weak_ratio_used = float(swings_df["weak_any"].mean()) if len(swings_df) else 0.0
+    median_leg = (
+        float(swings_df["leg_from_prev"].median(skipna=True)) if len(swings_df) else 0.0
+    )
+
+    summary = {
+        "n_levels_in": n_levels_in,
+        "n_levels_used": n_levels_used,
+        "n_swings": n_swings,
+        "merge_same_type_count": int(swings_df.attrs.get("merge_same_type_count", 0)),
+        "merge_nearby_count": int(swings_df.attrs.get("merge_nearby_count", 0)),
+        "weak_ratio_in": weak_ratio_in,
+        "weak_ratio_used": weak_ratio_used,
+        "median_leg_from_prev": median_leg,
+        "params": asdict(cfg),
+    }
+    return summary

--- a/tests/test_structure_swings.py
+++ b/tests/test_structure_swings.py
@@ -1,0 +1,136 @@
+from pathlib import Path
+import json
+import sys
+
+import pandas as pd
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from alpha.structure.swings import SwingsCfg, build_swings
+from alpha.app.cli import (
+    analyze_levels_data,
+    analyze_levels_formation,
+    analyze_levels_prop,
+    analyze_structure_swings,
+)
+
+
+def _sample_df(n=10):
+    idx = pd.date_range("2020", periods=n, freq="H", tz="UTC")
+    price = pd.Series(range(n), index=idx, dtype="float64") + 10
+    df = pd.DataFrame(
+        {
+            "open": price + 0.1,
+            "high": price + 0.2,
+            "low": price - 0.2,
+            "close": price,
+        }
+    )
+    return df
+
+
+def test_merge_same_type():
+    df = _sample_df(6)
+    levels = pd.DataFrame(
+        [
+            {"time": df.index[1], "type": "peak", "price": 11.0, "end_idx": 1},
+            {"time": df.index[2], "type": "peak", "price": 12.0, "end_idx": 2},
+            {"time": df.index[4], "type": "trough", "price": 14.0, "end_idx": 4},
+        ]
+    )
+    cfg = SwingsCfg(atr_window=3)
+    swings = build_swings(df, levels, cfg)
+    assert len(swings) == 2
+    first = swings.iloc[0]
+    assert first["type"] == "peak"
+    assert first["price"] == 12.0
+
+
+def test_merge_nearby_price():
+    df = _sample_df(5)
+    levels = pd.DataFrame(
+        [
+            {"time": df.index[1], "type": "trough", "price": 11.0, "end_idx": 1},
+            {"time": df.index[3], "type": "peak", "price": 11.1, "end_idx": 3},
+        ]
+    )
+    cfg = SwingsCfg(swing_merge_atr_mult=0.3, atr_window=3)
+    swings = build_swings(df, levels, cfg)
+    assert len(swings) == 1
+
+
+def test_min_gap_merge():
+    df = _sample_df(5)
+    levels = pd.DataFrame(
+        [
+            {"time": df.index[1], "type": "trough", "price": 11.0, "end_idx": 1},
+            {"time": df.index[2], "type": "peak", "price": 12.5, "end_idx": 2},
+        ]
+    )
+    cfg = SwingsCfg(swing_merge_atr_mult=0.0, min_gap_bars=2, min_price_delta_atr_mult=0.0, atr_window=3)
+    swings = build_swings(df, levels, cfg)
+    assert len(swings) == 1
+
+
+def test_filter_weak_levels():
+    df = _sample_df(5)
+    levels = pd.DataFrame(
+        [
+            {"time": df.index[1], "type": "peak", "price": 11.0, "end_idx": 1, "weak_prop": True},
+            {"time": df.index[2], "type": "trough", "price": 10.0, "end_idx": 2, "weak_prop": False},
+        ]
+    )
+    cfg = SwingsCfg(atr_window=3)
+    swings = build_swings(df, levels, cfg)
+    assert len(swings) == 1
+    assert swings.iloc[0]["type"] == "trough"
+
+
+def test_integration_structure_swings(tmp_path):
+    data_dir = tmp_path / "data"
+    analyze_levels_data(
+        data="data/EURUSD_H1.tsv",
+        symbol="EURUSD",
+        tf="H1",
+        tz="UTC",
+        outdir=str(data_dir),
+    )
+    parquet = data_dir / "ohlc.parquet"
+    levels_dir = tmp_path / "levels"
+    analyze_levels_formation(
+        parquet=str(parquet),
+        symbol="EURUSD",
+        tf="H1",
+        profile="h1",
+        outdir=str(levels_dir),
+    )
+    analyze_levels_prop(
+        parquet=str(parquet),
+        levels_csv=str(levels_dir / "levels_formation.csv"),
+        symbol="EURUSD",
+        tf="H1",
+        profile="h1",
+        outdir=str(levels_dir),
+    )
+    outdir = tmp_path / "swings"
+    analyze_structure_swings(
+        parquet=str(parquet),
+        levels_csv=str(levels_dir / "levels_prop.csv"),
+        symbol="EURUSD",
+        tf="H1",
+        profile="h1",
+        outdir=str(outdir),
+    )
+
+    swings_csv = outdir / "swings.csv"
+    assert swings_csv.exists()
+    swings_df = pd.read_csv(swings_csv, parse_dates=["time"])
+    assert not (swings_df["type"].shift() == swings_df["type"]).any()
+    if len(swings_df) > 1:
+        assert swings_df["leg_from_prev"].iloc[1:].mean() > 0
+    summary_path = outdir / "swings_summary.json"
+    with summary_path.open("r", encoding="utf-8") as fh:
+        summary = json.load(fh)
+    assert summary["n_swings"] == len(swings_df)
+    assert summary["n_levels_used"] == int(swings_df["merged_count"].sum())


### PR DESCRIPTION
## Summary
- construct robust price swings from processed levels with alternation, proximity merging, and ATR-based filters
- add CLI entry analyze-structure-swings to generate swing artifacts and summaries
- cover swing construction with unit and integration tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad66cd3e8083248206db9603ac05e0