### PR TITLE
Implement swing builder with CLI and tests

### DIFF
--- a/alpha/app/cli.py
+++ b/alpha/app/cli.py
@@ -23,6 +23,7 @@ from alpha.levels.break_update import (
 )
 from alpha.eval.levels_metrics import compute_levels_metrics, score_levels
 from alpha.viz.levels import LevelsVizCfg, build_level_segments, plot_levels
+from alpha.structure.swings import SwingsCfg, build_swings, summarize_swings
 
 
 def analyze_levels_data(data: str, symbol: str, tf: str, tz: str, outdir: str) -> None:
@@ -376,6 +377,69 @@ def analyze_levels_viz(
         seg_full.to_csv(out_path / "levels_segments_full.csv", index=False)
         mark_full.to_csv(out_path / "levels_markers_full.csv", index=False)
 
+
+def analyze_structure_swings(
+    parquet: str,
+    levels_csv: str,
+    symbol: str,
+    tf: str,
+    profile: str,
+    outdir: str,
+) -> None:
+    """Build structure swings and write artifacts."""
+
+    df = pd.read_parquet(parquet)
+    levels_df = pd.read_csv(levels_csv)
+    if "time" in levels_df.columns:
+        levels_df["time"] = pd.to_datetime(levels_df["time"], utc=True, errors="coerce")
+
+    cfg_path = Path(__file__).resolve().parents[1] / "config" / "structure.yml"
+    cfg_dict = {}
+    if cfg_path.exists():
+        with cfg_path.open("r", encoding="utf-8") as fh:
+            cfg_dict = yaml.safe_load(fh) or {}
+    profile_cfg = cfg_dict.get("profiles", {}).get(profile, {})
+
+    cfg = SwingsCfg(
+        use_only_strong_swings=bool(
+            profile_cfg.get("use_only_strong_swings", SwingsCfg.use_only_strong_swings)
+        ),
+        swing_merge_atr_mult=float(
+            profile_cfg.get("swing_merge_atr_mult", SwingsCfg.swing_merge_atr_mult)
+        ),
+        min_gap_bars=int(profile_cfg.get("min_gap_bars", SwingsCfg.min_gap_bars)),
+        min_price_delta_atr_mult=float(
+            profile_cfg.get(
+                "min_price_delta_atr_mult", SwingsCfg.min_price_delta_atr_mult
+            )
+        ),
+        keep_latest_on_tie=bool(
+            profile_cfg.get("keep_latest_on_tie", SwingsCfg.keep_latest_on_tie)
+        ),
+        atr_window=int(profile_cfg.get("atr_window", SwingsCfg.atr_window)),
+    )
+
+    swings_df = build_swings(df, levels_df, cfg)
+    summary = summarize_swings(swings_df, levels_df, cfg)
+
+    out_path = Path(outdir)
+    out_path.mkdir(parents=True, exist_ok=True)
+
+    swings_out = swings_df.copy()
+    swings_out["src_level_ids"] = swings_out["src_level_ids"].apply(
+        lambda ids: ",".join(map(str, ids))
+    )
+    swings_out.to_csv(out_path / "swings.csv", index=False)
+
+    with (out_path / "swings_summary.json").open("w", encoding="utf-8") as fh:
+        json.dump(summary, fh, indent=2)
+
+    print(
+        f"levels_in={summary['n_levels_in']}, levels_used={summary['n_levels_used']}, "
+        f"swings={summary['n_swings']}, merge_same={summary['merge_same_type_count']}, "
+        f"merge_nearby={summary['merge_nearby_count']}"
+    )
+
 # ---- CLI wiring ----
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -439,6 +503,13 @@ def _build_parser() -> argparse.ArgumentParser:
     p.add_argument("--last-n-bars", type=int, default=500)
     p.add_argument("--full", action="store_true")
 
+    p = sub.add_parser("analyze-structure-swings")
+    p.add_argument("--parquet", required=True)
+    p.add_argument("--levels", required=True)
+    p.add_argument("--symbol", required=True)
+    p.add_argument("--tf", required=True)
+    p.add_argument("--profile", required=True)
+    p.add_argument("--outdir", required=True)
 
     return parser
 
@@ -499,7 +570,6 @@ def main() -> None:
             eval_profile=args.eval_profile,
             outdir=args.outdir,
         )
-    
     elif args.command == "analyze-levels-viz":
         analyze_levels_viz(
             parquet=args.parquet,
@@ -510,6 +580,15 @@ def main() -> None:
             outdir=args.outdir,
             last_n_bars=args.last_n_bars,
             full=args.full,
+        )
+    elif args.command == "analyze-structure-swings":
+        analyze_structure_swings(
+            parquet=args.parquet,
+            levels_csv=args.levels,
+            symbol=args.symbol,
+            tf=args.tf,
+            profile=args.profile,
+            outdir=args.outdir,
         )
     else:
         parser.print_help()

--- a/alpha/structure/swings.py
+++ b/alpha/structure/swings.py
@@ -1,0 +1,238 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+import pandas as pd
+from pandas import Timestamp
+
+from alpha.core.indicators import atr
+
+SwingType = Literal["peak", "trough"]
+
+
+@dataclass
+class SwingsCfg:
+    use_only_strong_swings: bool = True
+    swing_merge_atr_mult: float = 0.10
+    min_gap_bars: int = 1
+    min_price_delta_atr_mult: float = 0.05
+    keep_latest_on_tie: bool = True
+    atr_window: int = 14
+
+
+def _prepare_levels(levels_df: pd.DataFrame, cfg: SwingsCfg) -> pd.DataFrame:
+    lv = levels_df.copy()
+    if "time" in lv.columns:
+        lv["time"] = pd.to_datetime(lv["time"], utc=True, errors="coerce")
+    sort_col = "end_idx" if "end_idx" in lv.columns else "time"
+    lv = lv.sort_values(sort_col).reset_index(drop=True)
+    if "level_id" not in lv.columns:
+        lv["level_id"] = range(len(lv))
+    cols = [c for c in ["time", "end_idx", "type", "price", "weak_prop", "level_id"] if c in lv.columns]
+    lv = lv[cols]
+    if cfg.use_only_strong_swings and "weak_prop" in lv.columns:
+        lv = lv[lv["weak_prop"] != True].reset_index(drop=True)
+    return lv
+
+
+def build_swings(df: pd.DataFrame, levels_df: pd.DataFrame, cfg: SwingsCfg) -> pd.DataFrame:
+    levels = _prepare_levels(levels_df, cfg)
+    atr_series = atr(df, window=cfg.atr_window)
+    eps = 1e-12
+
+    swings: list[dict] = []
+    merge_same = 0
+    for row in levels.itertuples():
+        swing = {
+            "time": row.time if isinstance(row.time, Timestamp) else pd.to_datetime(row.time, utc=True),
+            "idx": int(getattr(row, "end_idx", getattr(row, "idx", 0))),
+            "type": row.type,
+            "price": float(row.price),
+            "src_level_ids": [int(row.level_id)],
+            "merged_count": 1,
+            "weak_any": bool(getattr(row, "weak_prop", False)),
+        }
+        if not swings:
+            swings.append(swing)
+            continue
+        last = swings[-1]
+        if swing["type"] == last["type"]:
+            merge_same += 1
+            if swing["type"] == "peak":
+                take_new = swing["price"] > last["price"] or (
+                    swing["price"] == last["price"] and cfg.keep_latest_on_tie
+                )
+            else:
+                take_new = swing["price"] < last["price"] or (
+                    swing["price"] == last["price"] and cfg.keep_latest_on_tie
+                )
+            last["src_level_ids"].extend(swing["src_level_ids"])
+            last["merged_count"] += 1
+            last["weak_any"] = last["weak_any"] or swing["weak_any"]
+            if take_new:
+                last.update({k: swing[k] for k in ["time", "idx", "price"]})
+        else:
+            swings.append(swing)
+
+    merge_near = 0
+    i = 1
+    while i < len(swings):
+        prev = swings[i - 1]
+        cur = swings[i]
+        price_delta = abs(cur["price"] - prev["price"])
+        atr_ref = float(atr_series.iloc[cur["idx"]]) if cur["idx"] < len(atr_series) else 0.0
+        atr_ref = max(atr_ref, eps)
+        gap_bars = cur["idx"] - prev["idx"]
+        if (
+            price_delta <= atr_ref * cfg.swing_merge_atr_mult
+            or gap_bars < cfg.min_gap_bars
+            or price_delta <= atr_ref * cfg.min_price_delta_atr_mult
+        ):
+            merge_near += 1
+            if cur["type"] == "peak":
+                keep_cur = cur["price"] >= prev["price"]
+                if cur["price"] == prev["price"]:
+                    keep_cur = cfg.keep_latest_on_tie
+            else:
+                keep_cur = cur["price"] <= prev["price"]
+                if cur["price"] == prev["price"]:
+                    keep_cur = cfg.keep_latest_on_tie
+            if keep_cur:
+                cur["src_level_ids"] = prev["src_level_ids"] + cur["src_level_ids"]
+                cur["merged_count"] += prev["merged_count"]
+                cur["weak_any"] = cur["weak_any"] or prev["weak_any"]
+                if cur["type"] == "peak" and prev["price"] > cur["price"]:
+                    cur.update({k: prev[k] for k in ["time", "idx", "price"]})
+                if cur["type"] == "trough" and prev["price"] < cur["price"]:
+                    cur.update({k: prev[k] for k in ["time", "idx", "price"]})
+                del swings[i - 1]
+            else:
+                prev["src_level_ids"].extend(cur["src_level_ids"])
+                prev["merged_count"] += cur["merged_count"]
+                prev["weak_any"] = prev["weak_any"] or cur["weak_any"]
+                if cur["type"] == "peak" and cur["price"] > prev["price"]:
+                    prev.update({k: cur[k] for k in ["time", "idx", "price"]})
+                if cur["type"] == "trough" and cur["price"] < prev["price"]:
+                    prev.update({k: cur[k] for k in ["time", "idx", "price"]})
+                del swings[i]
+            i = max(i - 1, 1)
+        else:
+            i += 1
+
+    # Final pass to enforce alternation
+    final_sw: list[dict] = []
+    for sw in swings:
+        if final_sw and sw["type"] == final_sw[-1]["type"]:
+            merge_near += 1
+            last = final_sw[-1]
+            if sw["type"] == "peak":
+                take_new = sw["price"] > last["price"] or (
+                    sw["price"] == last["price"] and cfg.keep_latest_on_tie
+                )
+            else:
+                take_new = sw["price"] < last["price"] or (
+                    sw["price"] == last["price"] and cfg.keep_latest_on_tie
+                )
+            last["src_level_ids"].extend(sw["src_level_ids"])
+            last["merged_count"] += sw["merged_count"]
+            last["weak_any"] = last["weak_any"] or sw["weak_any"]
+            if take_new:
+                last.update({k: sw[k] for k in ["time", "idx", "price"]})
+        else:
+            final_sw.append(sw)
+    swings = final_sw
+
+    # Build DataFrame with helper fields
+    out = pd.DataFrame(swings)
+    if out.empty:
+        out["swing_id"] = []
+        out["leg_from_prev"] = []
+        out["leg_to_next"] = []
+        out["atr_at_idx"] = []
+        out["min_gap_bars"] = []
+        out.attrs["merge_same_type_count"] = merge_same
+        out.attrs["merge_nearby_count"] = merge_near
+        return out
+
+    out["swing_id"] = range(len(out))
+    leg_from_prev = [float("nan")]
+    gap_from_prev = [0]
+    for i in range(1, len(out)):
+        leg_from_prev.append(abs(out.loc[i, "price"] - out.loc[i - 1, "price"]))
+        gap_from_prev.append(int(out.loc[i, "idx"] - out.loc[i - 1, "idx"]))
+    leg_to_next = [abs(out.loc[i + 1, "price"] - out.loc[i, "price"]) for i in range(len(out) - 1)]
+    leg_to_next.append(float("nan"))
+    atr_vals = [float(atr_series.iloc[int(idx)]) if int(idx) < len(atr_series) else float("nan") for idx in out["idx"]]
+
+    out["leg_from_prev"] = leg_from_prev
+    out["leg_to_next"] = leg_to_next
+    out["atr_at_idx"] = atr_vals
+    out["min_gap_bars"] = gap_from_prev
+
+    out = out[
+        [
+            "swing_id",
+            "time",
+            "idx",
+            "type",
+            "price",
+            "src_level_ids",
+            "merged_count",
+            "weak_any",
+            "min_gap_bars",
+            "leg_from_prev",
+            "leg_to_next",
+            "atr_at_idx",
+        ]
+    ]
+
+    out.attrs["merge_same_type_count"] = merge_same
+    out.attrs["merge_nearby_count"] = merge_near
+    return out
+
+
+def summarize_swings(swings_df: pd.DataFrame, levels_df: pd.DataFrame, cfg: SwingsCfg) -> dict:
+    n_levels_in = int(len(levels_df))
+    n_swings = int(len(swings_df))
+    n_levels_used = int(swings_df["merged_count"].sum()) if n_swings else 0
+    merge_same = int(swings_df.attrs.get("merge_same_type_count", 0))
+    merge_near = int(swings_df.attrs.get("merge_nearby_count", 0))
+
+    weak_ratio_in = 0.0
+    weak_ratio_used = 0.0
+    if "weak_prop" in levels_df.columns and n_levels_in:
+        weak_ratio_in = float(levels_df["weak_prop"].mean())
+        if n_levels_used:
+            if "level_id" not in levels_df.columns:
+                levels_df = levels_df.copy()
+                levels_df["level_id"] = range(len(levels_df))
+            weak_map = levels_df.set_index("level_id")["weak_prop"].to_dict()
+            used_ids: list[int] = []
+            for ids in swings_df["src_level_ids"]:
+                used_ids.extend(ids)
+            weak_vals = [weak_map.get(i, False) for i in used_ids]
+            weak_ratio_used = float(pd.Series(weak_vals).mean()) if used_ids else 0.0
+
+    median_leg = (
+        float(swings_df["leg_from_prev"].median(skipna=True)) if n_swings else 0.0
+    )
+
+    return {
+        "n_levels_in": n_levels_in,
+        "n_levels_used": n_levels_used,
+        "n_swings": n_swings,
+        "merge_same_type_count": merge_same,
+        "merge_nearby_count": merge_near,
+        "weak_ratio_in": weak_ratio_in,
+        "weak_ratio_used": weak_ratio_used,
+        "median_leg_from_prev": median_leg,
+        "params": {
+            "use_only_strong_swings": cfg.use_only_strong_swings,
+            "swing_merge_atr_mult": cfg.swing_merge_atr_mult,
+            "min_gap_bars": cfg.min_gap_bars,
+            "min_price_delta_atr_mult": cfg.min_price_delta_atr_mult,
+            "keep_latest_on_tie": cfg.keep_latest_on_tie,
+            "atr_window": cfg.atr_window,
+        },
+    }

--- a/tests/test_structure_swings.py
+++ b/tests/test_structure_swings.py
@@ -1,0 +1,123 @@
+from pathlib import Path
+import sys
+import json
+
+import pandas as pd
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from alpha.structure.swings import SwingsCfg, build_swings
+from alpha.app.cli import (
+    analyze_levels_data,
+    analyze_levels_formation,
+    analyze_levels_prop,
+    analyze_structure_swings,
+)
+
+
+def _sample_df():
+    idx = pd.date_range("2020", periods=6, freq="H", tz="UTC")
+    close = [10.0, 11.0, 10.5, 10.7, 10.6, 10.8]
+    open_ = close
+    high = [c + 0.2 for c in close]
+    low = [c - 0.2 for c in close]
+    return pd.DataFrame({"open": open_, "high": high, "low": low, "close": close}, index=idx)
+
+
+def test_merge_same_type():
+    df = _sample_df()
+    levels = pd.DataFrame([
+        {"time": df.index[1], "end_idx": 1, "type": "peak", "price": 11.0},
+        {"time": df.index[2], "end_idx": 2, "type": "peak", "price": 12.0},
+    ])
+    res = build_swings(df, levels, SwingsCfg())
+    assert len(res) == 1
+    assert res.loc[0, "price"] == 12.0
+    assert res.loc[0, "merged_count"] == 2
+
+
+def test_merge_nearby_price():
+    df = _sample_df()
+    levels = pd.DataFrame([
+        {"time": df.index[1], "end_idx": 1, "type": "trough", "price": 10.9},
+        {"time": df.index[2], "end_idx": 2, "type": "peak", "price": 10.91},
+    ])
+    cfg = SwingsCfg(swing_merge_atr_mult=1.0, min_price_delta_atr_mult=0.0, min_gap_bars=1)
+    res = build_swings(df, levels, cfg)
+    assert len(res) == 1
+
+
+def test_min_gap_bars():
+    df = _sample_df()
+    levels = pd.DataFrame([
+        {"time": df.index[1], "end_idx": 1, "type": "trough", "price": 10.9},
+        {"time": df.index[2], "end_idx": 2, "type": "peak", "price": 11.2},
+    ])
+    cfg = SwingsCfg(min_gap_bars=3, swing_merge_atr_mult=0.0, min_price_delta_atr_mult=0.0)
+    res = build_swings(df, levels, cfg)
+    assert len(res) == 1
+
+
+def test_use_only_strong_swings():
+    df = _sample_df()
+    levels = pd.DataFrame([
+        {"time": df.index[1], "end_idx": 1, "type": "peak", "price": 11.0, "weak_prop": True},
+        {"time": df.index[2], "end_idx": 2, "type": "trough", "price": 10.5, "weak_prop": False},
+        {"time": df.index[3], "end_idx": 3, "type": "peak", "price": 11.5, "weak_prop": False},
+    ])
+    res = build_swings(df, levels, SwingsCfg(use_only_strong_swings=True))
+    used_ids = [i for ids in res["src_level_ids"] for i in ids]
+    assert len(res) == 2
+    assert 0 not in used_ids
+    assert not res["weak_any"].any()
+
+
+def test_integration_swings(tmp_path):
+    data_dir = tmp_path / "data"
+    analyze_levels_data(
+        data="data/EURUSD_H1.tsv",
+        symbol="EURUSD",
+        tf="H1",
+        tz="UTC",
+        outdir=str(data_dir),
+    )
+    parquet_path = data_dir / "ohlc.parquet"
+    levels_dir = tmp_path / "levels"
+    analyze_levels_formation(
+        parquet=str(parquet_path),
+        symbol="EURUSD",
+        tf="H1",
+        profile="h1",
+        outdir=str(levels_dir),
+    )
+    levels_csv = levels_dir / "levels_formation.csv"
+    prop_dir = tmp_path / "prop"
+    analyze_levels_prop(
+        parquet=str(parquet_path),
+        levels_csv=str(levels_csv),
+        symbol="EURUSD",
+        tf="H1",
+        profile="h1",
+        outdir=str(prop_dir),
+    )
+    struct_dir = tmp_path / "structure"
+    analyze_structure_swings(
+        parquet=str(parquet_path),
+        levels_csv=str(prop_dir / "levels_prop.csv"),
+        symbol="EURUSD",
+        tf="H1",
+        profile="h1",
+        outdir=str(struct_dir),
+    )
+    swings_path = struct_dir / "swings.csv"
+    summary_path = struct_dir / "swings_summary.json"
+    assert swings_path.exists()
+    assert summary_path.exists()
+    swings_df = pd.read_csv(swings_path)
+    assert not (swings_df["type"].shift(1) == swings_df["type"]).any()
+    if len(swings_df) > 1:
+        assert swings_df["leg_from_prev"].iloc[1:].mean() > 0
+    with summary_path.open("r", encoding="utf-8") as fh:
+        summary = json.load(fh)
+    assert summary["n_swings"] == len(swings_df)


### PR DESCRIPTION
## Summary
- add `SwingsCfg` and `build_swings` to generate alternating price swings with ATR-based merging and helper metrics
- expose new `analyze-structure-swings` CLI command to build swings and summaries
- add unit and integration tests for swing construction and CLI pipeline

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad68ff5e4c8324bf959675c6b94495