### PR TITLE
Add Asia session liquidity analyzer

### DIFF
--- a/alpha/config/liquidity.yml
+++ b/alpha/config/liquidity.yml
@@ -1,5 +1,16 @@
-asia_session:
-  start_h: 0
-  end_h: 8
+profiles:
+  h1:
+    asia_session:
+      start_h: 0
+      end_h: 8
+      tz_source: "UTC"
+    post_session:
+      breakout_lookahead_h: 6
+      confirm_with_body: true
+    atr:
+      window: 14
+    formatting:
+      pip_size: 0.0001
+      tick_size: 0.0
 cluster:
   eq_atr_tol: 0.06

--- a/alpha/liquidity/asia.py
+++ b/alpha/liquidity/asia.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, asdict
+from typing import Literal
+import warnings
+
+import numpy as np
+import pandas as pd
+
+from alpha.core.indicators import atr
+
+Direction = Literal["up", "down", "none"]
+
+
+@dataclass
+class AsiaCfg:
+    start_h: int = 0
+    end_h: int = 8
+    breakout_lookahead_h: int = 6
+    confirm_with_body: bool = True
+    atr_window: int = 14
+    pip_size: float = 0.0001
+    tick_size: float = 0.0
+    tz_source: str = "UTC"
+
+
+def _round_width(width: float, cfg: AsiaCfg) -> float:
+    if cfg.tick_size > 0:
+        return round(width / cfg.tick_size) * cfg.tick_size
+    return width
+
+
+def compute_asia_range_for_day(df_day: pd.DataFrame, cfg: AsiaCfg) -> dict:
+    """Compute asia session range and post-session interactions for a day."""
+
+    if "day_start" in df_day.attrs:
+        day_start: pd.Timestamp = df_day.attrs["day_start"]
+    else:
+        day_start = df_day.index[0].normalize()
+
+    start_ts = day_start + pd.Timedelta(hours=cfg.start_h)
+    end_ts = day_start + pd.Timedelta(hours=cfg.end_h)
+    day_end = day_start + pd.Timedelta(days=1)
+    post_end = end_ts + pd.Timedelta(hours=cfg.breakout_lookahead_h)
+
+    day_slice = df_day.loc[(df_day.index >= day_start) & (df_day.index < day_end)]
+    asia_df = day_slice.loc[(day_slice.index >= start_ts) & (day_slice.index < end_ts)]
+
+    record = {
+        "date": day_start.date(),
+        "start_ts": start_ts,
+        "end_ts": end_ts,
+        "asia_high": np.nan,
+        "asia_low": np.nan,
+        "asia_mid": np.nan,
+        "width": np.nan,
+        "width_pips": np.nan,
+        "width_atr_norm": np.nan,
+        "time_high": pd.NaT,
+        "time_low": pd.NaT,
+        "post_first_touch_dir": "none",
+        "post_first_break_dir": "none",
+        "post_first_touch_ts": pd.NaT,
+        "post_first_break_ts": pd.NaT,
+        "label": "NoData",
+        "notes": "",
+    }
+
+    if asia_df.empty:
+        return record
+
+    asia_high = float(asia_df["high"].max())
+    asia_low = float(asia_df["low"].min())
+    time_high = asia_df["high"].idxmax()
+    time_low = asia_df["low"].idxmin()
+    width = _round_width(asia_high - asia_low, cfg)
+    asia_mid = asia_low + width / 2
+
+    atr_series = atr(day_slice, window=cfg.atr_window)
+    atr_ref = float(atr_series.iloc[-1]) if len(atr_series.dropna()) else 0.0
+    eps = 1e-12
+    width_atr_norm = width / max(atr_ref, eps)
+    width_pips = width / cfg.pip_size if cfg.pip_size else np.nan
+
+    record.update(
+        {
+            "asia_high": asia_high,
+            "asia_low": asia_low,
+            "asia_mid": asia_mid,
+            "width": width,
+            "width_pips": width_pips,
+            "width_atr_norm": width_atr_norm,
+            "time_high": time_high,
+            "time_low": time_low,
+            "label": "NoInteraction",
+        }
+    )
+
+    up_edge = asia_high
+    down_edge = asia_low
+    post_df = df_day.loc[(df_day.index >= end_ts) & (df_day.index <= post_end)]
+
+    first_touch_dir: Direction = "none"
+    first_break_dir: Direction = "none"
+    first_touch_ts = pd.NaT
+    first_break_ts = pd.NaT
+
+    for ts, bar in post_df.iterrows():
+        close = float(bar["close"])
+        high = float(bar["high"])
+        low = float(bar["low"])
+        if cfg.confirm_with_body:
+            touch_up = close >= up_edge
+            touch_dn = close <= down_edge
+        else:
+            touch_up = high >= up_edge
+            touch_dn = low <= down_edge
+        break_up = close > up_edge
+        break_dn = close < down_edge
+
+        if first_touch_dir == "none" and (touch_up or touch_dn):
+            first_touch_dir = "up" if touch_up else "down"
+            first_touch_ts = ts
+        if first_break_dir == "none" and (break_up or break_dn):
+            first_break_dir = "up" if break_up else "down"
+            first_break_ts = ts
+        if first_touch_dir != "none" and first_break_dir != "none":
+            break
+
+    record.update(
+        {
+            "post_first_touch_dir": first_touch_dir,
+            "post_first_break_dir": first_break_dir,
+            "post_first_touch_ts": first_touch_ts,
+            "post_first_break_ts": first_break_ts,
+        }
+    )
+
+    if first_break_dir == "up":
+        record["label"] = "BreakUp"
+    elif first_break_dir == "down":
+        record["label"] = "BreakDown"
+    elif first_touch_dir != "none":
+        record["label"] = "BothTouch_NoBreak"
+    else:
+        record["label"] = "NoInteraction"
+
+    return record
+
+
+def asia_range_daily(df: pd.DataFrame, cfg: AsiaCfg) -> pd.DataFrame:
+    if df.index.tz is None:
+        df = df.tz_localize(cfg.tz_source)
+    else:
+        tz_name = str(df.index.tz)
+        if cfg.tz_source and tz_name != cfg.tz_source:
+            warnings.warn(
+                f"tz_source {cfg.tz_source} differs from dataframe tz {tz_name}; using dataframe tz",
+                RuntimeWarning,
+            )
+
+    records = []
+    for day_start, _ in df.groupby(df.index.normalize()):
+        post_end = day_start + pd.Timedelta(
+            hours=cfg.end_h + cfg.breakout_lookahead_h
+        )
+        df_slice = df.loc[day_start:post_end].copy()
+        df_slice.attrs["day_start"] = day_start
+        record = compute_asia_range_for_day(df_slice, cfg)
+        records.append(record)
+    return pd.DataFrame(records)
+
+
+def summarize_asia_ranges(daily_df: pd.DataFrame, cfg: AsiaCfg) -> dict:
+    valid = daily_df[daily_df["label"] != "NoData"]
+    n_days = int(len(daily_df))
+    width_pips_stats = {
+        "p25": float(valid["width_pips"].quantile(0.25)) if not valid.empty else float("nan"),
+        "median": float(valid["width_pips"].median()) if not valid.empty else float("nan"),
+        "p75": float(valid["width_pips"].quantile(0.75)) if not valid.empty else float("nan"),
+    }
+    width_atr_norm_stats = {
+        "p25": float(valid["width_atr_norm"].quantile(0.25)) if not valid.empty else float("nan"),
+        "median": float(valid["width_atr_norm"].median()) if not valid.empty else float("nan"),
+        "p75": float(valid["width_atr_norm"].quantile(0.75)) if not valid.empty else float("nan"),
+    }
+    denom = len(valid) if not valid.empty else 1
+    summary = {
+        "n_days": n_days,
+        "width_pips_stats": width_pips_stats,
+        "width_atr_norm_stats": width_atr_norm_stats,
+        "break_up_share": float((valid["label"] == "BreakUp").sum() / denom),
+        "break_down_share": float((valid["label"] == "BreakDown").sum() / denom),
+        "both_touch_share": float((valid["label"] == "BothTouch_NoBreak").sum() / denom),
+        "no_interaction_share": float((valid["label"] == "NoInteraction").sum() / denom),
+        "params": asdict(cfg),
+    }
+    return summary

--- a/tests/test_liquidity_asia.py
+++ b/tests/test_liquidity_asia.py
@@ -1,0 +1,98 @@
+from pathlib import Path
+import sys
+
+# Ensure project root on path when running via `uv run`
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import pandas as pd
+import numpy as np
+import pytest
+import json
+
+from alpha.liquidity.asia import AsiaCfg, asia_range_daily, summarize_asia_ranges
+from alpha.app.cli import analyze_liquidity_asia
+
+
+def _make_df_break_up():
+    idx = pd.date_range("2023-01-01", periods=60, freq="15min", tz="UTC")
+    base = 1.0
+    open_ = np.full(len(idx), base)
+    close = np.full(len(idx), base)
+    high = np.full(len(idx), base + 0.02)
+    low = np.full(len(idx), base - 0.02)
+    high[36] = base + 0.03
+    close[36] = base + 0.03
+    return pd.DataFrame({"open": open_, "high": high, "low": low, "close": close}, index=idx)
+
+
+def _make_df_touch_only():
+    idx = pd.date_range("2023-01-01", periods=60, freq="15min", tz="UTC")
+    base = 1.0
+    open_ = np.full(len(idx), base)
+    close = np.full(len(idx), base)
+    high = np.full(len(idx), base + 0.02)
+    low = np.full(len(idx), base - 0.02)
+    # touch but no break at 09:00
+    close[36] = base + 0.02
+    return pd.DataFrame({"open": open_, "high": high, "low": low, "close": close}, index=idx)
+
+
+def _make_df_no_interaction():
+    idx = pd.date_range("2023-01-01", periods=60, freq="15min", tz="UTC")
+    base = 1.0
+    open_ = np.full(len(idx), base)
+    close = np.full(len(idx), base)
+    high = np.full(len(idx), base + 0.019)
+    low = np.full(len(idx), base - 0.019)
+    return pd.DataFrame({"open": open_, "high": high, "low": low, "close": close}, index=idx)
+
+
+def test_break_up_range():
+    df = _make_df_break_up()
+    cfg = AsiaCfg(atr_window=1, pip_size=0.01)
+    daily = asia_range_daily(df, cfg)
+    row = daily.iloc[0]
+    assert row["label"] == "BreakUp"
+    assert row["post_first_break_dir"] == "up"
+    assert row["width_pips"] == pytest.approx(4.0)
+    assert row["width_atr_norm"] == pytest.approx(1.0)
+
+
+def test_touch_no_break():
+    df = _make_df_touch_only()
+    cfg = AsiaCfg(atr_window=1, pip_size=0.01)
+    row = asia_range_daily(df, cfg).iloc[0]
+    assert row["label"] == "BothTouch_NoBreak"
+    assert row["post_first_touch_dir"] == "up"
+    assert row["post_first_break_dir"] == "none"
+
+
+def test_no_interaction():
+    df = _make_df_no_interaction()
+    cfg = AsiaCfg(atr_window=1, pip_size=0.01)
+    row = asia_range_daily(df, cfg).iloc[0]
+    assert row["label"] == "NoInteraction"
+    assert row["post_first_touch_dir"] == "none"
+    assert row["post_first_break_dir"] == "none"
+
+
+def test_cli_outputs(tmp_path):
+    df1 = _make_df_break_up()
+    df2 = _make_df_no_interaction()
+    df2.index = df2.index + pd.Timedelta(days=1)
+    df = pd.concat([df1, df2])
+    parquet_path = tmp_path / "ohlc.parquet"
+    df.to_parquet(parquet_path)
+
+    outdir = tmp_path / "out"
+    analyze_liquidity_asia(str(parquet_path), "TEST", "M15", "h1", str(outdir))
+
+    daily_csv = outdir / "asia_range_daily.csv"
+    summary_json = outdir / "asia_range_summary.json"
+    assert daily_csv.exists() and summary_json.exists()
+
+    daily_df = pd.read_csv(daily_csv)
+    with open(summary_json, "r", encoding="utf-8") as fh:
+        summary = json.load(fh)
+    assert len(daily_df) == 2
+    assert summary["n_days"] == 2


### PR DESCRIPTION
## Summary
- add Asia session range extraction with ATR normalization and post-session touch/break detection
- expose `analyze-liquidity-asia` CLI to write session tables and summaries
- extend liquidity configuration with session, ATR, and formatting options

## Testing
- `pytest tests/test_liquidity_asia.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad961b8b9c83248e181f93a610aab2