### PR TITLE
Add basic Backtrader backtest runner

### DIFF
--- a/alpha/app/cli.py
+++ b/alpha/app/cli.py
@@ -49,6 +49,7 @@ from alpha.backtest.vbt_bridge import (
     run_vectorbt,
 )
 from alpha.backtest.metrics import summarize_bt
+from alpha.backtest.bt_runner import run_backtest_bt
 
 
 def analyze_levels_data(data: str, symbol: str, tf: str, tz: str, outdir: str) -> None:
@@ -1075,6 +1076,36 @@ def run_execution_cli(
     )
 
 
+def run_backtest_bt_cli(
+    m1_parquet: str,
+    zones_csv: str,
+    symbol: str,
+    htf: str,
+    outdir: str,
+    profile: str = "bt_m1",
+    trend_timeline_csv: str | None = None,
+    sweeps_csv: str | None = None,
+    asia_daily_csv: str | None = None,
+    eq_clusters_csv: str | None = None,
+) -> None:
+    summary = run_backtest_bt(
+        m1_parquet=m1_parquet,
+        zones_csv=zones_csv,
+        symbol=symbol,
+        htf=htf,
+        outdir=outdir,
+        profile=profile,
+        trend_timeline_csv=trend_timeline_csv,
+        sweeps_csv=sweeps_csv,
+        asia_daily_csv=asia_daily_csv,
+        eq_clusters_csv=eq_clusters_csv,
+    )
+    print(
+        f"n_trades={summary.get('n_trades',0)} win_rate={summary.get('win_rate_trades',0):.2f} "
+        f"avg_R={summary.get('avg_R',0):.3f} maxDD_R={summary.get('max_dd_R',0):.2f}"
+    )
+
+
 
 def run_backtest_vbt(
     m1_parquet: str,
@@ -1316,6 +1347,18 @@ def _build_parser() -> argparse.ArgumentParser:
     p.add_argument("--start")
     p.add_argument("--end")
 
+    p = sub.add_parser("run-backtest-bt")
+    p.add_argument("--m1-parquet", required=True)
+    p.add_argument("--zones", required=True)
+    p.add_argument("--symbol", required=True)
+    p.add_argument("--htf", required=True)
+    p.add_argument("--outdir", required=True)
+    p.add_argument("--profile", default="bt_m1")
+    p.add_argument("--trend-timeline")
+    p.add_argument("--sweeps")
+    p.add_argument("--asia-daily")
+    p.add_argument("--eq-clusters")
+
     return parser
 
 
@@ -1489,6 +1532,19 @@ def main() -> None:
             start=args.start,
             end=args.end,
             initial_equity=args.initial_equity,
+        )
+    elif args.command == "run-backtest-bt":
+        run_backtest_bt_cli(
+            m1_parquet=args.m1_parquet,
+            zones_csv=args.zones,
+            symbol=args.symbol,
+            htf=args.htf,
+            outdir=args.outdir,
+            profile=args.profile,
+            trend_timeline_csv=args.trend_timeline,
+            sweeps_csv=args.sweeps,
+            asia_daily_csv=args.asia_daily,
+            eq_clusters_csv=args.eq_clusters,
         )
     elif args.command == "run-backtest-vbt":
         run_backtest_vbt(

--- a/alpha/backtest/__init__.py
+++ b/alpha/backtest/__init__.py
@@ -2,6 +2,9 @@
 
 from .vbt_bridge import VBTCfg, prepare_context, derive_signals, run_vectorbt
 from .metrics import summarize_bt
+from .bt_runner import run_backtest_bt
+from .bt_broker import BrokerCfg
+from .bt_strategy import StratCfg, POIExecutionStrategy
 
 __all__ = [
     "VBTCfg",
@@ -9,4 +12,8 @@ __all__ = [
     "derive_signals",
     "run_vectorbt",
     "summarize_bt",
+    "run_backtest_bt",
+    "BrokerCfg",
+    "StratCfg",
+    "POIExecutionStrategy",
 ]

--- a/alpha/backtest/bt_broker.py
+++ b/alpha/backtest/bt_broker.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+from __future__ import annotations
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import backtrader as bt
+
+
+@dataclass
+class BrokerCfg:
+    spread_pips: float = 0.1
+    slippage_pips: float = 0.1
+    commission_per_million: float = 30.0
+    comm_apply_both_sides: bool = True
+    pip_size: float = 0.0001
+    contract_size: float = 100000
+
+
+class _SpreadCommissionInfo(bt.CommInfoBase):
+    """Commission scheme applying spread, slippage and per notional fees."""
+
+    def __init__(self, cfg: BrokerCfg) -> None:
+        super().__init__()
+        self.cfg = cfg
+
+    def getoperationprice(self, price, isbuy):  # type: ignore[override]
+        adj = (self.cfg.spread_pips / 2 + self.cfg.slippage_pips) * self.cfg.pip_size
+        return price + adj if isbuy else price - adj
+
+    def getcommission(self, size, price, pseudoexec=False):  # type: ignore[override]
+        notional = abs(size) * price
+        comm = notional * self.cfg.commission_per_million / 1_000_000
+        if self.cfg.comm_apply_both_sides:
+            comm /= 2.0
+        return comm
+
+
+def build_broker_and_sizers(cerebro: bt.Cerebro, cfg: BrokerCfg) -> None:
+    """Configure broker with commission, spread and slippage models."""
+    comminfo = _SpreadCommissionInfo(cfg)
+    cerebro.broker.addcommissioninfo(comminfo)

--- a/alpha/backtest/bt_runner.py
+++ b/alpha/backtest/bt_runner.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+import pandas as pd
+import backtrader as bt
+import yaml
+
+from .bt_broker import BrokerCfg, build_broker_and_sizers
+from .bt_strategy import POIExecutionStrategy, StratCfg
+from .metrics import summarize_bt
+
+
+@dataclass
+class BTRunCfg:
+    start: Optional[str] = None
+    end: Optional[str] = None
+    initial_equity: float = 10000.0
+    profile: str = "bt_m1"
+
+
+def _load_profile(profile: str) -> dict:
+    cfg_path = Path(__file__).resolve().parents[1] / "config" / "backtest.yml"
+    data: dict = {}
+    if cfg_path.exists():
+        with cfg_path.open("r", encoding="utf-8") as fh:
+            data = yaml.safe_load(fh) or {}
+    return data.get("profiles", {}).get(profile, {})
+
+
+def run_backtest_bt(
+    m1_parquet: str,
+    zones_csv: str,
+    symbol: str,
+    htf: str,
+    outdir: str,
+    trend_timeline_csv: Optional[str] = None,
+    sweeps_csv: Optional[str] = None,
+    asia_daily_csv: Optional[str] = None,
+    eq_clusters_csv: Optional[str] = None,
+    profile: str = "bt_m1",
+    broker_cfg_override: Optional[BrokerCfg] = None,
+) -> dict:
+    """Run simple backtrader based backtest."""
+
+    profile_cfg = _load_profile(profile)
+    risk_cfg = profile_cfg.get("risk", {})
+    fees_cfg = profile_cfg.get("fees", {})
+    strat_cfg = StratCfg(
+        allow_sessions=profile_cfg.get("allow_sessions", []),
+        session_hours_utc=profile_cfg.get("session_hours_utc", {}),
+        min_minutes_between_trades=profile_cfg.get("min_minutes_between_trades", 0),
+        max_concurrent_trades=profile_cfg.get("max_concurrent_trades", 1),
+        one_trade_per_zone=profile_cfg.get("one_trade_per_zone", False),
+        use_trend_filter=profile_cfg.get("use_trend_filter", False),
+        min_zone_grade=profile_cfg.get("min_zone_grade", "B"),
+        zone_staleness_max_bars=profile_cfg.get("zone_staleness_max_bars", 0),
+        require_nearby_sweep=profile_cfg.get("require_nearby_sweep", False),
+        triggers=profile_cfg.get("triggers", {}),
+        risk=risk_cfg,
+        risk_caps=profile_cfg.get("risk_caps", {}),
+    )
+
+    broker_cfg = broker_cfg_override or BrokerCfg(
+        spread_pips=fees_cfg.get("spread_pips", 0.0),
+        slippage_pips=fees_cfg.get("slippage_pips", 0.0),
+        commission_per_million=fees_cfg.get("commission_per_million", 0.0),
+        comm_apply_both_sides=fees_cfg.get("comm_apply_both_sides", True),
+        pip_size=risk_cfg.get("pip_size", 0.0001),
+        contract_size=risk_cfg.get("contract_size", 100000),
+    )
+
+    m1_df = pd.read_parquet(m1_parquet)
+    zones_df = pd.read_csv(zones_csv)
+
+    cerebro = bt.Cerebro()
+    cerebro.broker.setcash(profile_cfg.get("initial_equity", 10000.0))
+    build_broker_and_sizers(cerebro, broker_cfg)
+    data_feed = bt.feeds.PandasData(dataname=m1_df)
+    cerebro.adddata(data_feed)
+    cerebro.addstrategy(POIExecutionStrategy, cfg=strat_cfg, zones=zones_df)
+    strat = cerebro.run()[0]
+
+    out_path = Path(outdir)
+    out_path.mkdir(parents=True, exist_ok=True)
+    trades_df = pd.DataFrame(strat.trade_logs)
+    fills_df = pd.DataFrame(strat.fill_logs)
+    equity_df = pd.DataFrame(strat.equity_logs)
+    trades_df.to_csv(out_path / "trades.csv", index=False)
+    fills_df.to_csv(out_path / "fills.csv", index=False)
+    equity_df.to_csv(out_path / "equity_curve.csv", index=False)
+    summary = summarize_bt(trades_df, equity_df)
+    (out_path / "bt_summary.json").write_text(pd.Series(summary).to_json())
+    return summary

--- a/alpha/backtest/bt_strategy.py
+++ b/alpha/backtest/bt_strategy.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Optional
+
+import backtrader as bt
+import pandas as pd
+
+from .bt_broker import BrokerCfg
+
+
+@dataclass
+class StratCfg:
+    allow_sessions: List[str]
+    session_hours_utc: Dict[str, List[int]]
+    min_minutes_between_trades: int
+    max_concurrent_trades: int
+    one_trade_per_zone: bool
+    use_trend_filter: bool
+    min_zone_grade: str
+    zone_staleness_max_bars: int
+    require_nearby_sweep: bool
+    triggers: Dict
+    risk: Dict
+    risk_caps: Dict
+
+
+class POIExecutionStrategy(bt.Strategy):
+    params = (
+        ("cfg", None),
+        ("zones", None),
+    )
+
+    def __init__(self) -> None:
+        self.cfg: StratCfg = self.params.cfg
+        self.zones: pd.DataFrame = self.params.zones if self.params.zones is not None else pd.DataFrame()
+        self.zones = self.zones.copy()
+        self.order_meta: Dict[int, Dict] = {}
+        self.trade_logs: List[Dict] = []
+        self.fill_logs: List[Dict] = []
+        self.equity_logs: List[Dict] = []
+        self.trade_seq = 1
+
+    # --- helpers -----------------------------------------------------
+    def _calc_size(self, weight: float) -> float:
+        return max(int(round(weight * 100)), 1)
+
+    def _build_brackets(
+        self, side: str, entry_price: float, sl: float, tps: List[float], weights: List[float], meta: Dict
+    ) -> None:
+        for i, (tp, w) in enumerate(zip(tps, weights), start=1):
+            size = self._calc_size(w)
+            if side == "long":
+                parent, stop, limit = self.buy_bracket(
+                    size=size,
+                    price=entry_price,
+                    stopprice=sl,
+                    limitprice=tp,
+                    exectype=bt.Order.Market,
+                )
+            else:
+                parent, stop, limit = self.sell_bracket(
+                    size=size,
+                    price=entry_price,
+                    stopprice=sl,
+                    limitprice=tp,
+                    exectype=bt.Order.Market,
+                )
+            info = dict(meta)
+            info.update({"leg": i, "side": side, "tp": tp, "sl": sl})
+            parent.addinfo(**info)
+            stop.addinfo(**info, order_role="sl")
+            limit.addinfo(**info, order_role="tp")
+            self.order_meta[parent.ref] = info
+        self.trade_seq += 1
+
+    # --- core --------------------------------------------------------
+    def next(self) -> None:  # pragma: no cover - heavy on backtrader internals
+        dt = bt.num2date(self.data.datetime[0])
+        equity = self.broker.getvalue()
+        self.equity_logs.append(
+            {
+                "time": dt,
+                "equity": equity,
+                "dd_R": 0.0,
+                "drawdown": 0.0,
+                "open_legs": len(self.order_meta),
+            }
+        )
+        if len(self.order_meta) >= self.cfg.max_concurrent_trades:
+            return
+        if self.zones.empty:
+            return
+        price = self.data.close[0]
+        zone = self.zones.iloc[0]
+        if zone["kind"].lower() == "demand":
+            if zone["price_bottom"] <= price <= zone["price_top"]:
+                entry = price
+                sl = zone["price_bottom"]
+                dist = entry - sl
+                tps = [entry + dist * leg["r"] for leg in self.cfg.risk.get("legs", [])]
+                weights = [leg["weight"] for leg in self.cfg.risk.get("legs", [])]
+                meta = {"trade_id": self.trade_seq, "zone_id": zone.get("zone_id", 0), "trigger": "touch"}
+                self._build_brackets("long", entry, sl, tps, weights, meta)
+                self.zones = self.zones.iloc[1:]
+        else:
+            if zone["price_bottom"] <= price <= zone["price_top"]:
+                entry = price
+                sl = zone["price_top"]
+                dist = sl - entry
+                tps = [entry - dist * leg["r"] for leg in self.cfg.risk.get("legs", [])]
+                weights = [leg["weight"] for leg in self.cfg.risk.get("legs", [])]
+                meta = {"trade_id": self.trade_seq, "zone_id": zone.get("zone_id", 0), "trigger": "touch"}
+                self._build_brackets("short", entry, sl, tps, weights, meta)
+                self.zones = self.zones.iloc[1:]
+
+    # --- notifications -----------------------------------------------
+    def notify_order(self, order):  # pragma: no cover - handled in bt
+        if order.status in [order.Completed, order.Partial]:
+            dt = bt.num2date(order.executed.dt)
+            self.fill_logs.append(
+                {
+                    "time": dt,
+                    "ref": order.ref,
+                    "price": order.executed.price,
+                    "size": order.executed.size,
+                    "order_role": order.info.get("order_role", "entry"),
+                    "trade_id": order.info.get("trade_id"),
+                    "leg": order.info.get("leg"),
+                    "side": order.info.get("side"),
+                }
+            )
+            if order.info.get("order_role", "entry") == "entry":
+                meta = self.order_meta.get(order.ref)
+                if meta is not None:
+                    meta["entry_time"] = dt
+                    meta["entry"] = order.executed.price
+
+    def notify_trade(self, trade):  # pragma: no cover - handled in bt
+        if not trade.isclosed:
+            return
+        meta = self.order_meta.get(trade.ref, {})
+        entry = meta.get("entry", trade.price)
+        pnl_usd = trade.pnlcomm
+        size = trade.size
+        if meta.get("side") == "long":
+            exit_price = entry + pnl_usd / size if size != 0 else entry
+            pnl_pips = pnl_usd / (self.cfg.risk["pip_size"] * self.cfg.risk["contract_size"])
+            risk_pips = (entry - meta.get("sl", entry)) / self.cfg.risk["pip_size"]
+        else:
+            exit_price = entry - pnl_usd / abs(size) if size != 0 else entry
+            pnl_pips = pnl_usd / (self.cfg.risk["pip_size"] * self.cfg.risk["contract_size"])
+            risk_pips = (meta.get("sl", entry) - entry) / self.cfg.risk["pip_size"]
+        pnl_R = pnl_pips / risk_pips if risk_pips else 0.0
+        self.trade_logs.append(
+            {
+                "trade_id": meta.get("trade_id", 0),
+                "leg": meta.get("leg", 0),
+                "side": meta.get("side"),
+                "zone_id": meta.get("zone_id"),
+                "trigger": meta.get("trigger"),
+                "entry_time": meta.get("entry_time"),
+                "entry": entry,
+                "sl_init": meta.get("sl"),
+                "sl_final": meta.get("sl"),
+                "tp": meta.get("tp"),
+                "exit_time": bt.num2date(self.data.datetime[0]),
+                "exit": exit_price,
+                "pnl_pips": pnl_pips,
+                "pnl_R": pnl_R,
+                "pnl_usd": pnl_usd,
+                "mae_R": 0.0,
+                "mfe_R": 0.0,
+                "fees_usd": trade.commission,
+                "tags_json": "{}",
+            }
+        )
+        self.order_meta.pop(trade.ref, None)

--- a/alpha/backtest/metrics.py
+++ b/alpha/backtest/metrics.py
@@ -30,6 +30,7 @@ def summarize_bt(trades_df: pd.DataFrame, equity_df: pd.DataFrame) -> Dict:
 
     trades_df = trades_df.copy()
     trades_df["win"] = trades_df["pnl_R"] > 0
+    trades_df["entry_time"] = pd.to_datetime(trades_df.get("entry_time"), errors="coerce")
 
     summary["n_trades"] = int(trades_df["trade_id"].nunique())
     summary["n_legs"] = int(len(trades_df))

--- a/alpha/config/backtest.yml
+++ b/alpha/config/backtest.yml
@@ -36,5 +36,56 @@ profiles:
       trailing:
         mode: "off"
         atr_mult: 1.5
+      fees:
+        use_vbt_fees: true
+  bt_m1:
+    start: null
+    end: null
+    initial_equity: 10000.0
+    allow_sessions: ["EU", "US"]
+    session_hours_utc:
+      AS: [0, 8]
+      EU: [7, 16]
+      US: [12, 21]
+    min_minutes_between_trades: 5
+    max_concurrent_trades: 2
+    one_trade_per_zone: true
+    use_trend_filter: true
+    min_zone_grade: "B"
+    zone_staleness_max_bars: 180
+    require_nearby_sweep: false
+    triggers:
+      touch_reject:
+        enabled: true
+        max_pen_atr_mult: 0.20
+        min_reject_wick_ratio: 0.4
+        confirm_with_body_against: true
+      choch_bos_in_zone:
+        enabled: true
+        min_internal_leg_atr_mult: 0.10
+        bos_confirm_k: 0.10
+        lookahead_bars: 6
+    risk:
+      risk_fixed_pct: 0.5
+      pip_size: 0.0001
+      contract_size: 100000
+      atr_window_m1: 14
+      sl_pad_atr_mult: 0.10
+      legs:
+        - { r: 1.0, weight: 0.30 }
+        - { r: 2.0, weight: 0.40 }
+        - { r: 3.0, weight: 0.30 }
+      breakeven_after_r: 1.0
+      trailing:
+        mode: "off"
+        atr_mult: 1.5
+        structure_swing_window: 10
     fees:
-      use_vbt_fees: true
+      spread_pips: 0.1
+      slippage_pips: 0.1
+      commission_per_million: 30.0
+      comm_apply_both_sides: true
+    risk_caps:
+      max_daily_loss_R: 3.0
+      max_weekly_loss_R: 7.0
+      stop_after_consecutive_losses: 3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "pyarrow>=21.0.0",
     "pydantic>=2.11.7",
     "pyyaml>=6.0.2",
+    "backtrader>=1.9.78.123",
 ]
 
 [dependency-groups]

--- a/tests/test_backtest_bt.py
+++ b/tests/test_backtest_bt.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from alpha.backtest.bt_runner import run_backtest_bt, BrokerCfg
+
+
+def _sample_data(tmp_path):
+    times = pd.date_range("2024-01-01", periods=4, freq="1min", tz="UTC")
+    df = pd.DataFrame(
+        {
+            "time": times,
+            "open": [1.0000, 1.0005, 1.0015, 1.0026],
+            "high": [1.0006, 1.0016, 1.0027, 1.0038],
+            "low": [0.9994, 1.0004, 1.0013, 1.0024],
+            "close": [1.0005, 1.0015, 1.0026, 1.0037],
+            "volume": [1, 1, 1, 1],
+        }
+    )
+    df = df.set_index("time")
+    m1 = tmp_path / "ohlc.parquet"
+    df.to_parquet(m1)
+    zones = pd.DataFrame(
+        {
+            "zone_id": [1],
+            "kind": ["demand"],
+            "price_top": [1.0006],
+            "price_bottom": [0.9994],
+            "grade": ["A"],
+        }
+    )
+    zcsv = tmp_path / "zones.csv"
+    zones.to_csv(zcsv, index=False)
+    return m1, zcsv
+
+
+def test_basic_backtest_bt(tmp_path):
+    m1, zones = _sample_data(tmp_path)
+    outdir = tmp_path / "out"
+    run_backtest_bt(
+        str(m1),
+        str(zones),
+        symbol="EURUSD",
+        htf="H1",
+        outdir=str(outdir),
+        broker_cfg_override=BrokerCfg(commission_per_million=0),
+    )
+    trades = pd.read_csv(outdir / "trades.csv")
+    assert len(trades) >= 1
+    assert trades["trade_id"].nunique() >= 1
+
+
+def test_commission_effect(tmp_path):
+    m1, zones = _sample_data(tmp_path)
+    out0 = tmp_path / "o0"
+    run_backtest_bt(
+        str(m1),
+        str(zones),
+        symbol="EURUSD",
+        htf="H1",
+        outdir=str(out0),
+        broker_cfg_override=BrokerCfg(commission_per_million=0),
+    )
+    pnl0 = pd.read_csv(out0 / "trades.csv")["pnl_usd"].sum()
+    out1 = tmp_path / "o1"
+    run_backtest_bt(
+        str(m1),
+        str(zones),
+        symbol="EURUSD",
+        htf="H1",
+        outdir=str(out1),
+        broker_cfg_override=BrokerCfg(commission_per_million=100),
+    )
+    pnl1 = pd.read_csv(out1 / "trades.csv")["pnl_usd"].sum()
+    assert pnl0 > pnl1


### PR DESCRIPTION
## Summary
- add simple Backtrader broker model with spread, slippage and commissions
- implement POIExecutionStrategy and run_backtest_bt utility
- wire Backtrader backtest into CLI and config
- cover Backtrader runner with tests

## Testing
- `pytest tests/test_backtest_bt.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68aea760f208832481bc4afb51b7fc9e