### PR TITLE
feat: generate static HTML reports

### DIFF
--- a/alpha/config/report.yml
+++ b/alpha/config/report.yml
@@ -1,0 +1,23 @@
+report:
+  title_prefix: "Alpha-POI Report"
+  logo_path: null
+  theme: "light"
+  last_n_bars_default: 500
+  date_format: "%Y-%m-%d %H:%M"
+  number_format:
+    pips_decimals: 1
+    price_decimals: 5
+  sections:
+    overview: true
+    structure: true
+    liquidity: true
+    poi: true
+    execution: true
+    backtests: true
+    appendix: true
+  tables:
+    max_rows_preview: 50
+  charts:
+    embed_png: true
+  notes:
+    show_params: true

--- a/alpha/report/__init__.py
+++ b/alpha/report/__init__.py
@@ -1,0 +1,17 @@
+"""Reporting utilities for Alpha Trading."""
+
+from .build_report import (
+    ReportCfg,
+    collect_artifacts,
+    load_metrics_and_tables,
+    render_html,
+    snapshot_params,
+)
+
+__all__ = [
+    "ReportCfg",
+    "collect_artifacts",
+    "load_metrics_and_tables",
+    "render_html",
+    "snapshot_params",
+]

--- a/alpha/report/build_report.py
+++ b/alpha/report/build_report.py
@@ -1,0 +1,242 @@
+from __future__ import annotations
+
+import json
+import shutil
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Dict, Optional
+
+import pandas as pd
+from jinja2 import Environment, FileSystemLoader
+
+from .utils import load_csv, load_json, relpath
+
+
+@dataclass
+class ReportCfg:
+    title_prefix: str = "Alpha-POI Report"
+    logo_path: str | None = None
+    theme: str = "light"
+    last_n_bars_default: int = 500
+    date_format: str = "%Y-%m-%d %H:%M"
+    number_format: Dict[str, Any] | None = None
+    sections: Dict[str, bool] | None = None
+    tables: Dict[str, Any] | None = None
+    charts: Dict[str, Any] | None = None
+    notes: Dict[str, Any] | None = None
+
+
+# ---------------------------------------------------------------------------
+# Artifact collection
+# ---------------------------------------------------------------------------
+
+def collect_artifacts(base_dir: str, symbol: str, tf: str) -> Dict[str, pd.Path]:
+    """Scan artifacts directory for standard files."""
+
+    from pathlib import Path
+
+    base = Path(base_dir)
+    paths: Dict[str, Path] = {}
+
+    token = f"{symbol}_{tf}"
+
+    # Structure
+    s_dir = base / "structure" / token
+    if s_dir.exists():
+        pngs = sorted(s_dir.glob("structure_last*.png"))
+        if pngs:
+            paths["structure_png"] = pngs[0]
+        t_timeline = s_dir / "trend_timeline.csv"
+        if t_timeline.exists():
+            paths["trend_timeline"] = t_timeline
+        t_summary = s_dir / "trend_summary.json"
+        if t_summary.exists():
+            paths["trend_summary"] = t_summary
+
+    # POI
+    p_dir = base / "poi" / token
+    if p_dir.exists():
+        pngs = sorted(p_dir.glob("poi_last*.png"))
+        if pngs:
+            paths["poi_png"] = pngs[0]
+        z_csv = p_dir / "poi_zones.csv"
+        if z_csv.exists():
+            paths["poi_zones"] = z_csv
+        z_sum = p_dir / "poi_summary.json"
+        if z_sum.exists():
+            paths["poi_summary"] = z_sum
+
+    # Liquidity
+    l_dir = base / "liquidity" / token
+    if l_dir.exists():
+        asia_csv = l_dir / "asia_range_daily.csv"
+        if asia_csv.exists():
+            paths["asia_range_daily"] = asia_csv
+        eq_csv = l_dir / "eq_clusters.csv"
+        if eq_csv.exists():
+            paths["eq_clusters"] = eq_csv
+        sw_csv = l_dir / "sweeps.csv"
+        if sw_csv.exists():
+            paths["sweeps"] = sw_csv
+
+    # Execution
+    e_dir = base / "execution" / token
+    if e_dir.exists():
+        t_csv = e_dir / "trades.csv"
+        if t_csv.exists():
+            paths["trades"] = t_csv
+        t_sum = e_dir / "trades_summary.json"
+        if t_sum.exists():
+            paths["trades_summary"] = t_sum
+        eq_curve = e_dir / "equity_curve.csv"
+        if eq_curve.exists():
+            paths["equity_curve"] = eq_curve
+
+    # Backtest
+    b_dir = base / "backtest" / token
+    if b_dir.exists():
+        bt_sum = b_dir / "bt_summary.json"
+        if bt_sum.exists():
+            paths["bt_summary"] = bt_sum
+        fills = b_dir / "fills.csv"
+        if fills.exists():
+            paths["fills"] = fills
+
+    return paths
+
+
+# ---------------------------------------------------------------------------
+# Metrics loading
+# ---------------------------------------------------------------------------
+
+def load_metrics_and_tables(paths: Dict[str, pd.Path]) -> Dict[str, Any]:
+    """Load JSON/CSV metrics and build DataFrame previews."""
+
+    kpi: Dict[str, Any] = {}
+    tables: Dict[str, pd.DataFrame] = {}
+
+    if p := paths.get("poi_zones"):
+        df = load_csv(p)
+        tables["poi_zones"] = df
+        if not df.empty:
+            kpi["poi"] = {
+                "n_zones": int(len(df)),
+                "median_width_pips": float(df.get("width_pips", pd.Series()).median(skipna=True)),
+            }
+
+    if p := paths.get("asia_range_daily"):
+        df = load_csv(p)
+        tables["asia_range_daily"] = df
+        if not df.empty:
+            kpi.setdefault("liquidity", {})["asia_break_up_share"] = float(
+                df.get("break_up", pd.Series()).mean(skipna=True)
+            )
+            kpi["liquidity"]["median_eq_width_pips"] = float(
+                df.get("width_pips", pd.Series()).median(skipna=True)
+            )
+
+    if p := paths.get("trend_summary"):
+        data = load_json(p)
+        if data:
+            kpi["structure"] = {
+                "share_up": data.get("share_time_up"),
+                "share_down": data.get("share_time_down"),
+                "share_range": data.get("share_time_range"),
+                "n_runs": data.get("n_reversals"),
+            }
+
+    if p := paths.get("trades_summary"):
+        data = load_json(p)
+        if data:
+            kpi["trades"] = {
+                "n": data.get("n_trades"),
+                "win_rate": data.get("win_rate"),
+                "avg_R": data.get("avg_R"),
+                "maxDD_R": data.get("maxDD_R"),
+            }
+
+    if p := paths.get("trades"):
+        df = load_csv(p)
+        if not df.empty:
+            df = df.sort_values(by=df.columns[0])
+            tables["trades"] = df
+
+    if p := paths.get("eq_clusters"):
+        df = load_csv(p)
+        if not df.empty:
+            tables["eq_clusters"] = df
+
+    if p := paths.get("sweeps"):
+        df = load_csv(p)
+        if not df.empty:
+            tables["sweeps"] = df
+
+    return kpi, tables
+
+
+# ---------------------------------------------------------------------------
+# Rendering
+# ---------------------------------------------------------------------------
+
+def render_html(
+    cfg: ReportCfg,
+    paths: Dict[str, pd.Path],
+    kpi: Dict[str, Any],
+    tables: Dict[str, pd.DataFrame],
+    out_html_path: str,
+    assets_dir: Optional[str] = None,
+) -> None:
+    from pathlib import Path
+
+    out_path = Path(out_html_path)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    images: Dict[str, str] = {}
+    if assets_dir:
+        assets = Path(assets_dir)
+        assets.mkdir(parents=True, exist_ok=True)
+    else:
+        assets = None
+
+    for key, p in paths.items():
+        if p and p.suffix.lower() == ".png":
+            if assets:
+                dest = assets / p.name
+                shutil.copy(p, dest)
+                images[key] = relpath(dest, out_path.parent)
+            else:
+                images[key] = relpath(p, out_path.parent)
+
+    table_html: Dict[str, str] = {}
+    table_links: Dict[str, str] = {}
+    for name, df in tables.items():
+        table_html[name] = df.to_html(index=False, float_format=lambda x: f"{x:.1f}")
+        original = paths.get(name)
+        if isinstance(original, Path) and original.exists():
+            table_links[name] = relpath(original, out_path.parent)
+
+    env = Environment(loader=FileSystemLoader(Path(__file__).resolve().parent / "templates"))
+    tmpl = env.get_template("base.html")
+    html = tmpl.render(title=cfg.title_prefix, images=images, tables=table_html, links=table_links, kpi=kpi)
+    with out_path.open("w", encoding="utf-8") as fh:
+        fh.write(html)
+
+
+# ---------------------------------------------------------------------------
+# Params snapshot
+# ---------------------------------------------------------------------------
+
+def snapshot_params(cfg_paths: Dict[str, str], out_path: str) -> None:
+    from pathlib import Path
+    import yaml
+
+    snapshot: Dict[str, Any] = {}
+    for name, path in cfg_paths.items():
+        p = Path(path)
+        if p.exists():
+            with p.open("r", encoding="utf-8") as fh:
+                snapshot[name] = yaml.safe_load(fh) or {}
+    out = Path(out_path)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    with out.open("w", encoding="utf-8") as fh:
+        json.dump(snapshot, fh, indent=2)

--- a/alpha/report/utils.py
+++ b/alpha/report/utils.py
@@ -1,0 +1,40 @@
+import json
+from pathlib import Path
+from typing import Any
+import os
+
+import pandas as pd
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    """Safely load a JSON file and return a dict."""
+    if not path or not path.exists():
+        return {}
+    with path.open("r", encoding="utf-8") as fh:
+        try:
+            return json.load(fh)
+        except json.JSONDecodeError:
+            return {}
+
+
+def load_csv(path: Path) -> pd.DataFrame:
+    """Safely load a CSV file and return a DataFrame."""
+    if not path or not path.exists():
+        return pd.DataFrame()
+    try:
+        return pd.read_csv(path)
+    except Exception:
+        return pd.DataFrame()
+
+
+def format_float(value: Any, decimals: int) -> str:
+    """Format a value as float with given decimals."""
+    try:
+        return f"{float(value):.{decimals}f}"
+    except Exception:
+        return ""
+
+
+def relpath(path: Path, start: Path) -> str:
+    """Return a POSIX relative path."""
+    return os.path.relpath(path, start).replace(os.sep, "/")

--- a/tests/test_report_html.py
+++ b/tests/test_report_html.py
@@ -1,0 +1,109 @@
+import json
+import re
+from pathlib import Path
+
+import pandas as pd
+import matplotlib.pyplot as plt
+
+# ensure project root on path
+import sys
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from alpha.app.cli import generate_report
+
+
+def _create_png(path: Path) -> None:
+    plt.figure()
+    plt.plot([1, 2], [1, 2])
+    plt.tight_layout()
+    plt.savefig(path)
+    plt.close()
+
+
+def _prepare_artifacts(base: Path) -> None:
+    token = "EURUSD_H1"
+    struct_dir = base / "structure" / token
+    struct_dir.mkdir(parents=True, exist_ok=True)
+    _create_png(struct_dir / "structure_last500.png")
+    (struct_dir / "trend_summary.json").write_text(
+        json.dumps({
+            "share_time_up": 0.4,
+            "share_time_down": 0.3,
+            "share_time_range": 0.3,
+            "n_reversals": 5,
+        })
+    )
+
+    poi_dir = base / "poi" / token
+    poi_dir.mkdir(parents=True, exist_ok=True)
+    pd.DataFrame(
+        {
+            "kind": ["A", "B"],
+            "grade": [1, 2],
+            "width_pips": [5.0, 6.0],
+            "score_total": [10, 8],
+        }
+    ).to_csv(poi_dir / "poi_zones.csv", index=False)
+
+    liq_dir = base / "liquidity" / token
+    liq_dir.mkdir(parents=True, exist_ok=True)
+    pd.DataFrame(
+        {
+            "date": ["2020-01-01", "2020-01-02"],
+            "width_pips": [10.0, 12.0],
+            "break_up": [1, 0],
+        }
+    ).to_csv(liq_dir / "asia_range_daily.csv", index=False)
+
+    exe_dir = base / "execution" / token
+    exe_dir.mkdir(parents=True, exist_ok=True)
+    (exe_dir / "trades_summary.json").write_text(
+        json.dumps({"n_trades": 2, "win_rate": 0.5, "avg_R": 1.2, "maxDD_R": -0.5})
+    )
+
+
+def test_report_html_smoke(tmp_path: Path):
+    base = tmp_path / "artifacts"
+    _prepare_artifacts(base)
+
+    outdir = base / "reports" / "EURUSD_H1"
+    generate_report(symbol="EURUSD", tf="H1", outdir=str(outdir))
+
+    html_files = list(outdir.glob("report_*.html"))
+    assert html_files, "HTML report not generated"
+    html_text = html_files[0].read_text()
+    assert "Alpha-POI Report" in html_text
+    assert "<img" in html_text
+    assert "<table" in html_text
+    assert "Download CSV" in html_text
+
+    snap = json.loads((outdir / "params_snapshot.json").read_text())
+    assert "structure.yml" in snap
+
+
+def test_report_html_missing_sections(tmp_path: Path):
+    base = tmp_path / "artifacts"
+    _prepare_artifacts(base)
+    # remove execution to simulate missing
+    import shutil
+    shutil.rmtree(base / "execution")
+
+    outdir = base / "reports" / "EURUSD_H1"
+    generate_report(symbol="EURUSD", tf="H1", outdir=str(outdir))
+    html_files = list(outdir.glob("report_*.html"))
+    assert html_files
+    html_text = html_files[0].read_text()
+    # trades section should be absent
+    assert "n_trades" not in html_text
+
+
+def test_number_formatting(tmp_path: Path):
+    base = tmp_path / "artifacts"
+    _prepare_artifacts(base)
+
+    outdir = base / "reports" / "EURUSD_H1"
+    generate_report(symbol="EURUSD", tf="H1", outdir=str(outdir))
+    html_files = list(outdir.glob("report_*.html"))
+    html_text = html_files[0].read_text()
+    # width_pips should be formatted with one decimal place
+    assert re.search(r"10\.0", html_text)


### PR DESCRIPTION
## Summary
- add generate-report CLI command producing HTML summaries
- compile artifacts and metrics into templated HTML output
- provide config, utilities, and tests for report generation

## Testing
- `pytest tests/test_report_html.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68aeae18abfc8324af67be73c6b95c8e