### PR TITLE
Add repository audit tool and CLI command

### DIFF
--- a/alpha/app/cli.py
+++ b/alpha/app/cli.py
@@ -11,6 +11,7 @@ import pandas as pd
 import yaml
 
 from alpha.ops.runner import RunCfg, run_pipeline
+from alpha.ops.audit import run_repo_audit
 
 from alpha.core.io import read_mt_tsv, to_parquet
 from alpha.core.indicators import atr, is_doji_series, true_range
@@ -1538,6 +1539,11 @@ def _build_parser() -> argparse.ArgumentParser:
     p.add_argument("--artifacts-root")
     p.add_argument("--runs-root")
 
+    p = sub.add_parser("repo-audit")
+    p.add_argument("--root", default=".")
+    p.add_argument("--outdir", default="artifacts/audit")
+    p.add_argument("--deep", action="store_true")
+
     return parser
 
 
@@ -1766,6 +1772,9 @@ def main() -> None:
             artifacts_root=args.artifacts_root,
             runs_root=args.runs_root,
         )
+    elif args.command == "repo-audit":
+        result = run_repo_audit(root=args.root, outdir=args.outdir, deep=args.deep)
+        raise SystemExit(result.get("exit_code", 0))
     elif args.command == "generate-report":
         generate_report(
             symbol=args.symbol,

--- a/alpha/ops/audit.py
+++ b/alpha/ops/audit.py
@@ -1,0 +1,305 @@
+from __future__ import annotations
+
+"""Repository audit utility.
+
+This module scans the repository and produces a report about implemented
+modules, configuration files, tests and CLI entry points.  Results are written
+as JSON, Markdown and CSV manifests.
+"""
+
+import csv
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import argparse
+import importlib.util
+
+from .audit_catalog import (
+    EXPECTED_CLI_COMMANDS,
+    TASK_FILE_MAP,
+    EXPECTED_CONFIGS,
+    EXPECTED_TESTS,
+    CRITICAL_CLI,
+)
+
+
+def import_cli_module(path: Path):
+    """Import ``alpha/app/cli.py`` from an arbitrary path.
+
+    Using importlib util to avoid depending on package installation.
+    """
+
+    spec = importlib.util.spec_from_file_location("repo_cli", path)
+    if spec is None or spec.loader is None:  # pragma: no cover - defensive
+        raise ImportError("cannot create spec for cli module")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)  # type: ignore[assignment]
+    return module
+
+
+def _discover_cli(path: Path, expected: List[str], deep: bool) -> Tuple[List[Dict], List[Dict], List[str]]:
+    """Discover CLI commands.
+
+    Returns tuple (present, missing, notes).
+    """
+
+    present: List[Dict] = []
+    missing: List[Dict] = []
+    notes: List[str] = []
+
+    if not path.exists():
+        for name in expected:
+            missing.append({"name": name, "expected_in": str(path)})
+        return present, missing, notes
+
+    if deep:
+        try:
+            module = import_cli_module(path)
+            if hasattr(module, "_build_parser"):
+                parser = module._build_parser()
+                names = set()
+                for action in parser._actions:
+                    if isinstance(action, argparse._SubParsersAction):
+                        names.update(action.choices.keys())
+                for name in expected:
+                    if name in names:
+                        present.append({"name": name, "path": str(path), "via": "import"})
+                    else:
+                        missing.append({"name": name, "expected_in": str(path)})
+                return present, missing, notes
+            else:  # pragma: no cover - unlikely
+                notes.append("_build_parser missing in cli module")
+        except Exception as exc:  # pragma: no cover - defensive
+            notes.append(f"import failed: {exc}")
+            present.clear()
+            missing.clear()
+            # fall back to regex below
+
+    # Fallback: simple text search
+    text = path.read_text(encoding="utf-8")
+    for name in expected:
+        if name in text:
+            present.append({"name": name, "path": str(path), "via": "regex"})
+        else:
+            missing.append({"name": name, "expected_in": str(path)})
+    return present, missing, notes
+
+
+def _file_status(p: Path) -> str:
+    if p.exists() and p.is_file() and p.stat().st_size > 0:
+        return "present"
+    elif p.exists() and p.is_file():
+        return "partial"
+    return "missing"
+
+
+def run_repo_audit(root: Path | str = Path("."), outdir: Path | str = Path("artifacts/audit"), *, deep: bool = False) -> Dict:
+    """Run repository audit.
+
+    Parameters
+    ----------
+    root: Path or str
+        Root of the repository to scan.
+    outdir: Path or str
+        Directory where reports should be written.
+    deep: bool
+        If ``True`` attempt to import the CLI module to discover commands.
+
+    Returns
+    -------
+    Dict
+        Report dictionary including ``exit_code`` key.
+    """
+
+    root = Path(root)
+    outdir = Path(outdir)
+    outdir.mkdir(parents=True, exist_ok=True)
+
+    manifest_rows: List[Dict[str, str]] = []
+
+    # Discover CLI commands
+    cli_path = root / "alpha" / "app" / "cli.py"
+    cli_present, cli_missing, cli_notes = _discover_cli(cli_path, EXPECTED_CLI_COMMANDS, deep)
+    manifest_rows.append({"path": str(cli_path), "status": _file_status(cli_path)})
+
+    # Evaluate tasks / clusters
+    clusters: Dict[str, Dict] = {}
+    tasks_total = 0
+    tasks_ok = 0
+    for cl_name, tasks in TASK_FILE_MAP.items():
+        cl_tasks: Dict[str, Dict] = {}
+        cl_statuses: List[str] = []
+        for task_code, files in tasks.items():
+            tasks_total += 1
+            file_statuses = []
+            for f in files:
+                p = root / f
+                st = _file_status(p)
+                manifest_rows.append({"path": f, "status": st})
+                file_statuses.append(st)
+            if all(st == "present" for st in file_statuses):
+                status = "implemented"
+                tasks_ok += 1
+            elif any(st != "missing" for st in file_statuses):
+                status = "partial"
+            else:
+                status = "missing"
+            cl_tasks[task_code] = {"files": files, "status": status}
+            cl_statuses.append(status)
+        if all(st == "implemented" for st in cl_statuses):
+            cl_status = "implemented"
+        elif any(st != "missing" for st in cl_statuses):
+            cl_status = "partial"
+        else:
+            cl_status = "missing"
+        clusters[cl_name] = {"status": cl_status, "tasks": cl_tasks}
+
+    # Config files
+    cfg_present: List[str] = []
+    cfg_missing: List[str] = []
+    for cfg in EXPECTED_CONFIGS:
+        p = root / cfg
+        st = _file_status(p)
+        manifest_rows.append({"path": cfg, "status": st})
+        if st == "present":
+            cfg_present.append(cfg)
+        else:
+            cfg_missing.append(cfg)
+
+    # Tests
+    tests_present: List[str] = []
+    tests_missing: List[str] = []
+    for tst in EXPECTED_TESTS:
+        p = root / tst
+        st = _file_status(p)
+        manifest_rows.append({"path": tst, "status": st})
+        if st == "present":
+            tests_present.append(tst)
+        else:
+            tests_missing.append(tst)
+
+    # Summary and grade
+    clusters_total = len(TASK_FILE_MAP)
+    clusters_ok = sum(1 for c in clusters.values() if c["status"] == "implemented")
+    cli_total = len(EXPECTED_CLI_COMMANDS)
+    cli_present_count = len(cli_present)
+    summary = {
+        "clusters_total": clusters_total,
+        "clusters_ok": clusters_ok,
+        "tasks_total": tasks_total,
+        "tasks_ok": tasks_ok,
+        "cli_total_expected": cli_total,
+        "cli_present": cli_present_count,
+        "configs_present": len(cfg_present),
+        "tests_present": len(tests_present),
+    }
+
+    coverage = 0.0
+    if tasks_total:
+        coverage += tasks_ok / tasks_total
+    if cli_total:
+        coverage += cli_present_count / cli_total
+    coverage /= 2 if coverage else 1
+    grade = "A" if coverage >= 0.8 else "B" if coverage >= 0.5 else "C"
+
+    executables = {
+        "cli": {"present": cli_present, "missing": cli_missing},
+        "scripts": {"present": [], "missing": []},
+    }
+    configs = {"present": cfg_present, "missing": cfg_missing}
+    tests = {"present": tests_present, "missing": tests_missing}
+
+    notes = "; ".join(cli_notes) if cli_notes else ""
+
+    report = {
+        "timestamp": datetime.utcnow().isoformat() + "Z",
+        "repo_root": str(root.resolve()),
+        "summary": summary,
+        "executables": executables,
+        "clusters": clusters,
+        "configs": configs,
+        "tests": tests,
+        "notes": notes,
+        "grade": grade,
+    }
+
+    # Write outputs
+    report_json = outdir / "report.json"
+    report_md = outdir / "REPORT.md"
+    manifest_csv = outdir / "manifest_files.csv"
+    with report_json.open("w", encoding="utf-8") as fh:
+        json.dump(report, fh, indent=2)
+    _write_report_md(report_md, clusters, cli_present, cfg_present, cfg_missing, tests_present, tests_missing)
+    with manifest_csv.open("w", encoding="utf-8", newline="") as fh:
+        writer = csv.DictWriter(fh, fieldnames=["path", "status"])
+        writer.writeheader()
+        for row in manifest_rows:
+            writer.writerow(row)
+
+    # Console output
+    print(
+        f"[repo-audit] clusters: ok={tasks_ok}/{tasks_total} tasks, cli={cli_present_count}/{cli_total} present, configs={len(cfg_present)}/{len(EXPECTED_CONFIGS)}, tests={len(tests_present)}/{len(EXPECTED_TESTS)}"
+    )
+    print(f"[repo-audit] report: {report_json}")
+    print(f"[repo-audit] summary: {report_md}")
+
+    # Critical CLI missing?
+    cli_present_names = {c["name"] for c in cli_present}
+    critical_missing = [c for c in CRITICAL_CLI if c not in cli_present_names]
+    if critical_missing:
+        print(f"[repo-audit] MISSING CRITICAL: {', '.join(critical_missing)}")
+    exit_code = 1 if critical_missing else 0
+    report["exit_code"] = exit_code
+    return report
+
+
+def _write_report_md(
+    path: Path,
+    clusters: Dict[str, Dict],
+    cli_present: List[Dict],
+    cfg_present: List[str],
+    cfg_missing: List[str],
+    tests_present: List[str],
+    tests_missing: List[str],
+) -> None:
+    """Write a human readable markdown summary."""
+
+    lines: List[str] = []
+    lines.append("# Repo Audit")
+    lines.append("")
+    lines.append("## Clusters")
+    lines.append("| Cluster | Status |")
+    lines.append("| --- | --- |")
+    for cl_name, cl in clusters.items():
+        lines.append(f"| {cl_name} | {cl['status']} |")
+    lines.append("")
+    lines.append("## CLI Commands")
+    lines.append("| Command | Status |")
+    lines.append("| --- | --- |")
+    present_names = {c["name"] for c in cli_present}
+    for name in EXPECTED_CLI_COMMANDS:
+        status = "present" if name in present_names else "missing"
+        lines.append(f"| {name} | {status} |")
+    lines.append("")
+    lines.append("## Configs")
+    lines.append("### Present")
+    for cfg in cfg_present:
+        lines.append(f"- {cfg}")
+    if cfg_missing:
+        lines.append("### Missing")
+        for cfg in cfg_missing:
+            lines.append(f"- {cfg}")
+    lines.append("")
+    lines.append("## Tests")
+    lines.append("### Present")
+    for t in tests_present:
+        lines.append(f"- {t}")
+    if tests_missing:
+        lines.append("### Missing")
+        for t in tests_missing:
+            lines.append(f"- {t}")
+    lines.append("")
+    path.write_text("\n".join(lines), encoding="utf-8")
+

--- a/alpha/ops/audit_catalog.py
+++ b/alpha/ops/audit_catalog.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+"""Catalog definitions for repo audit.
+
+This module contains the lists of expected CLI commands, task file mappings,
+configuration files, and tests.  The audit utility uses these structures to
+check the current repository.
+"""
+
+# Expected CLI commands exposed by ``alpha.app.cli``
+EXPECTED_CLI_COMMANDS = [
+    "fetch-data",
+    "run-pipeline",
+    "analyze-structure-swings",
+    "analyze-structure-events",
+    "analyze-structure-events-quality",
+    "analyze-structure-viz",
+    "analyze-structure-trend",
+    "analyze-liquidity-asia",
+    "analyze-liquidity-eq",
+    "analyze-liquidity-sweep",
+    "analyze-poi-ob",
+    "analyze-poi-viz",
+    "run-execution",
+    "run-backtest-vbt",
+    "run-backtest-bt",
+    "generate-report",
+]
+
+# Mapping of clusters and task identifiers to expected source files
+TASK_FILE_MAP = {
+    "structure": {
+        "S-01": ["alpha/structure/swings.py"],
+        "S-02": ["alpha/structure/events.py"],
+        "S-03": ["alpha/structure/quality.py"],
+        "S-04": ["alpha/viz/structure.py"],
+        "S-05": ["alpha/structure/trend.py"],
+    },
+    "liquidity": {
+        "LQ-01": ["alpha/liquidity/asia.py"],
+        "LQ-02": ["alpha/liquidity/eq.py"],
+        "LQ-03": ["alpha/liquidity/sweep.py"],
+    },
+    "poi": {
+        "POI-01": ["alpha/poi/ob.py"],
+        "POI-02": ["alpha/viz/poi.py"],
+    },
+    "execution": {
+        "EX-01": [
+            "alpha/execution/engine.py",
+            "alpha/execution/triggers.py",
+            "alpha/execution/risk.py",
+        ]
+    },
+    "backtests": {
+        "EX-02": ["alpha/backtest/vbt_bridge.py", "alpha/backtest/metrics.py"],
+        "EX-03": [
+            "alpha/backtest/bt_strategy.py",
+            "alpha/backtest/bt_broker.py",
+            "alpha/backtest/bt_runner.py",
+        ],
+    },
+    "report": {
+        "RP-01": ["alpha/report/build_report.py", "alpha/report/templates/base.html"],
+    },
+    "data": {
+        "DT-01": [
+            "alpha/data/ingest.py",
+            "alpha/data/normalize.py",
+            "alpha/data/validators.py",
+            "alpha/data/resample.py",
+            "alpha/data/merge.py",
+            "alpha/data/providers/base.py",
+            "alpha/data/providers/csv_local.py",
+            "alpha/app/cli.py",
+        ],
+        "DT-02": [
+            "alpha/data/providers/oanda_provider.py",
+            "alpha/data/providers/dukascopy_provider.py",
+        ],
+    },
+    "ops": {
+        "OPS-01": ["alpha/ops/runner.py", "alpha/ops/stages.py", "alpha/ops/registry.py"],
+        # OPS-03 refers to the audit itself; keep expected for completeness
+        "OPS-03": ["alpha/ops/audit.py", "alpha/ops/audit_catalog.py", "alpha/app/cli.py"],
+    },
+}
+
+# Expected configuration files
+EXPECTED_CONFIGS = [
+    "alpha/config/structure.yml",
+    "alpha/config/liquidity.yml",
+    "alpha/config/poi.yml",
+    "alpha/config/execution.yml",
+    "alpha/config/backtest.yml",
+    "alpha/config/viz.yml",
+    "alpha/config/report.yml",
+    "alpha/config/data.yml",
+    "alpha/config/instruments.yml",
+    "alpha/config/pipeline.yml",
+]
+
+# Suggested tests that should exist in the repository
+EXPECTED_TESTS = [
+    "tests/test_ops_pipeline.py",
+    "tests/test_data_ingest.py",
+    "tests/test_viz_poi.py",
+    "tests/test_execution_engine.py",
+    "tests/test_backtest_vbt.py",
+    "tests/test_backtest_bt.py",
+    "tests/test_report_html.py",
+    "tests/test_provider_oanda.py",
+    "tests/test_provider_duka.py",
+]
+
+# Critical CLI commands – if missing the audit should exit with non-zero status
+CRITICAL_CLI = {"fetch-data", "run-pipeline"}
+

--- a/alpha/report/templates/base.html
+++ b/alpha/report/templates/base.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>{{ title }}</title>
+  </head>
+  <body>
+    {% for key, img in images.items() %}
+    <img src="{{ img }}" alt="{{ key }}" />
+    {% endfor %}
+    {% for name, tbl in tables.items() %}
+    <h2>{{ name }}</h2>
+    {{ tbl|safe }}
+    {% if links.get(name) %}
+    <a href="{{ links[name] }}">Download CSV</a>
+    {% endif %}
+    {% endfor %}
+  </body>
+</html>

--- a/tests/test_ops_audit.py
+++ b/tests/test_ops_audit.py
@@ -1,0 +1,53 @@
+import json
+from pathlib import Path
+
+from alpha.ops.audit import run_repo_audit
+
+
+def test_repo_audit_smoke(tmp_path: Path):
+    outdir = tmp_path / "audit"
+    run_repo_audit(Path("."), outdir=outdir, deep=False)
+    assert (outdir / "report.json").exists()
+    assert (outdir / "REPORT.md").exists()
+    assert (outdir / "manifest_files.csv").exists()
+    data = json.loads((outdir / "report.json").read_text())
+    assert "summary" in data
+
+
+def test_cli_detection_and_partial_cluster(tmp_path: Path):
+    # Build a minimal repository
+    root = tmp_path / "repo"
+    (root / "alpha" / "app").mkdir(parents=True)
+    (root / "alpha" / "structure").mkdir(parents=True)
+    cli_code = (
+        "import argparse\n"
+        "def _build_parser():\n"
+        "    p = argparse.ArgumentParser()\n"
+        "    sub = p.add_subparsers(dest='command')\n"
+        "    sub.add_parser('fetch-data')\n"
+        "    return p\n"
+    )
+    (root / "alpha" / "app" / "cli.py").write_text(cli_code)
+    # Create empty file to trigger partial detection
+    (root / "alpha" / "structure" / "quality.py").write_text("")
+
+    outdir = root / "artifacts"
+    result = run_repo_audit(root=root, outdir=outdir, deep=False)
+    data = json.loads((outdir / "report.json").read_text())
+    assert result["exit_code"] != 0
+    missing_cli = {m["name"] for m in data["executables"]["cli"]["missing"]}
+    assert "run-pipeline" in missing_cli
+    assert data["clusters"]["structure"]["status"] == "partial"
+
+
+def test_deep_import_fallback(monkeypatch, tmp_path: Path):
+    from alpha.ops import audit as audit_mod
+
+    def bad_import(path: Path):
+        raise ImportError("boom")
+
+    monkeypatch.setattr(audit_mod, "import_cli_module", bad_import)
+    outdir = tmp_path / "audit"
+    res = audit_mod.run_repo_audit(Path("."), outdir=outdir, deep=True)
+    assert "import failed" in res.get("notes", "") or res.get("notes")
+    assert (outdir / "report.json").exists()


### PR DESCRIPTION
## Summary
- implement repository audit utility to scan for tasks, configs, tests, and CLI commands
- expose repo-audit command via alpha.app.cli
- provide markdown/JSON reports and manifest output; include base report template
- add tests for audit smoke, CLI detection, and import fallback

## Testing
- `python -m alpha.app.cli repo-audit --root . --outdir artifacts/audit`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aedb84f2ac8324adf3c550971caf89