### PR TITLE
feat: add scheduler module for automated runs

### DIFF
--- a/alpha/config/scheduler.yml
+++ b/alpha/config/scheduler.yml
@@ -1,0 +1,32 @@
+schedules:
+  daily_eur_usd_h1_m1:
+    enable: true
+    profile: "e2e_h1_m1"
+    symbol: "EURUSD"
+    htf: "H1"
+    ltf: "M1"
+    window:
+      mode: "rolling_days"
+      days: 30
+    when:
+      tz: "Europe/Berlin"
+      cron: "0 7 * * 1-5"
+    behavior:
+      force: false
+      resume: true
+      fail_fast: true
+      dry_run: false
+    backoff:
+      retries: 2
+      initial_s: 60
+      max_s: 600
+      factor: 2.0
+    notify:
+      on: ["success", "failure"]
+      channels:
+        slack:
+          enabled: true
+          webhook_env: "SLACK_WEBHOOK_URL"
+    retention:
+      runs_to_keep: 20
+      delete_old_artifacts: false

--- a/alpha/ops/notifiers.py
+++ b/alpha/ops/notifiers.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+"""Simple notification helpers for scheduler results."""
+
+from typing import Any, Dict, List
+import json
+import smtplib
+import urllib.request, urllib.parse
+from email.message import EmailMessage
+
+
+def fmt_summary_card(result: Dict[str, Any]) -> Dict[str, Any]:
+    """Format a human readable summary card from run result."""
+
+    status_emoji = "✅" if result.get("status") == "success" else "❌"
+    kpi = result.get("kpi", {})
+    parts: List[str] = [
+        f"{status_emoji} Alpha Pipeline — {result.get('symbol')} {result.get('htf')}/{result.get('ltf')}",
+        f"trades: {kpi.get('n_trades', 0)} | win_rate: {kpi.get('win_rate', 0)} | avg_R: {kpi.get('avg_R', 0)} | maxDD_R: {kpi.get('maxDD_R', 0)}",
+    ]
+    if result.get("report_path"):
+        parts.append(f"report: {result['report_path']}")
+    parts.append(f"run_id: {result.get('run_id')}")
+    return {"text": "\n".join(parts)}
+
+
+def notify_slack(webhook_url: str, card: Dict[str, Any]) -> None:
+    data = json.dumps({"text": card["text"]}).encode("utf-8")
+    req = urllib.request.Request(webhook_url, data=data, headers={"Content-Type": "application/json"})
+    urllib.request.urlopen(req)  # pragma: no cover - side effect
+
+
+def notify_telegram(bot_token: str, chat_id: str, card: Dict[str, Any]) -> None:
+    data = urllib.parse.urlencode({"chat_id": chat_id, "text": card["text"]}).encode("utf-8")
+    url = f"https://api.telegram.org/bot{bot_token}/sendMessage"
+    req = urllib.request.Request(url, data=data)
+    urllib.request.urlopen(req)  # pragma: no cover - side effect
+
+
+def notify_email(smtp_url: str, to: List[str], card: Dict[str, Any]) -> None:
+    msg = EmailMessage()
+    msg["Subject"] = "Alpha Pipeline Result"
+    msg["From"] = smtp_url
+    msg["To"] = ",".join(to)
+    msg.set_content(card["text"])
+    with smtplib.SMTP(smtp_url) as smtp:  # pragma: no cover - external side effect
+        smtp.send_message(msg)

--- a/alpha/ops/retention.py
+++ b/alpha/ops/retention.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+"""Retention helpers for pruning old pipeline runs."""
+
+from pathlib import Path
+from typing import Dict, Any
+import shutil
+
+
+def cleanup_runs(schedule_id: str, runs_root: str, keep_last: int, delete_artifacts: bool) -> Dict[str, Any]:
+    """Remove old run directories keeping only ``keep_last`` most recent."""
+
+    root = Path(runs_root)
+    if not root.exists():  # nothing to do
+        return {"deleted": [], "kept": [], "bytes_freed": 0}
+
+    run_dirs = sorted([p for p in root.iterdir() if p.is_dir()])
+    kept = [p.name for p in run_dirs[-keep_last:]] if keep_last else [p.name for p in run_dirs]
+    to_delete = run_dirs[:-keep_last] if keep_last else []
+    deleted = []
+    bytes_freed = 0
+    for d in to_delete:
+        if delete_artifacts:
+            for f in d.rglob("*"):
+                if f.is_file():
+                    bytes_freed += f.stat().st_size
+        shutil.rmtree(d, ignore_errors=True)
+        deleted.append(d.name)
+    return {"deleted": deleted, "kept": kept, "bytes_freed": bytes_freed}

--- a/alpha/ops/scheduler.py
+++ b/alpha/ops/scheduler.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+"""Scheduler for running pipeline profiles periodically."""
+
+from dataclasses import dataclass
+from typing import Dict, Any
+import json
+import logging
+import os
+import time
+from pathlib import Path
+from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
+
+import yaml
+
+from alpha.ops.runner import RunCfg, run_pipeline
+
+from .utils import build_window, next_cron_time
+from .retention import cleanup_runs
+from .notifiers import fmt_summary_card, notify_slack, notify_telegram, notify_email
+
+
+@dataclass
+class ScheduleCfg:
+    enable: bool
+    profile: str
+    symbol: str
+    htf: str
+    ltf: str
+    window: Dict[str, Any]
+    when: Dict[str, Any]
+    behavior: Dict[str, Any]
+    backoff: Dict[str, Any]
+    notify: Dict[str, Any]
+    retention: Dict[str, Any]
+
+
+def _load_profile(profile: str) -> Dict[str, Any]:
+    cfg_path = Path(__file__).resolve().parents[1] / "config" / "pipeline.yml"
+    data = yaml.safe_load(cfg_path.read_text())
+    return data["profiles"][profile]
+
+
+def run_once(schedule_id: str, cfg: ScheduleCfg) -> Dict[str, Any]:
+    """Execute pipeline for a schedule once and record results."""
+
+    logger = logging.getLogger(f"alpha.ops.scheduler.{schedule_id}")
+    window = build_window(cfg.window)
+
+    prof = _load_profile(cfg.profile)
+    behavior = prof.get("behavior", {}).copy()
+    behavior.update(cfg.behavior or {})
+    io = prof.get("io", {}).copy()
+    art_root_override = os.getenv("ALPHA_ARTIFACTS_ROOT")
+    if art_root_override:
+        io["artifacts_root"] = art_root_override
+        io["runs_root"] = str(Path(art_root_override) / "runs")
+    run_cfg = RunCfg(
+        profile=cfg.profile,
+        symbol=cfg.symbol,
+        htf=cfg.htf,
+        ltf=cfg.ltf,
+        start=window.start,
+        end=window.end,
+        stages=prof["stages"],
+        behavior=behavior,
+        io=io,
+    )
+
+    retries = int(cfg.backoff.get("retries", 0))
+    delay = float(cfg.backoff.get("initial_s", 0))
+    factor = float(cfg.backoff.get("factor", 2.0))
+    max_s = float(cfg.backoff.get("max_s", delay))
+    attempt = 0
+    while True:
+        try:
+            result = run_pipeline(run_cfg)
+            break
+        except Exception:  # pragma: no cover - defensive
+            attempt += 1
+            if attempt > retries:
+                raise
+            wait_s = min(max_s, delay * (factor ** (attempt - 1)))
+            time.sleep(wait_s)
+
+    manifest_path = Path(result["manifest_path"])
+    run_dir = manifest_path.parent
+    run_id = run_dir.name
+
+    kpi: Dict[str, Any] = {}
+    ts_path = run_dir / "trades_summary.json"
+    if ts_path.exists():
+        kpi.update(json.loads(ts_path.read_text()))
+    bt_path = run_dir / "bt_summary.json"
+    if bt_path.exists():
+        kpi.update(json.loads(bt_path.read_text()))
+
+    reports_dir = Path(io["artifacts_root"]) / "reports" / f"{cfg.symbol}_{cfg.htf}"
+    report_path = ""
+    if reports_dir.exists():
+        htmls = sorted(reports_dir.glob("report*.html"))
+        if htmls:
+            report_path = str(htmls[-1])
+
+    status = "success" if result.get("status") == "ok" else "failure"
+    sched_root = Path(io["artifacts_root"]) / "scheduler" / schedule_id
+    sched_root.mkdir(parents=True, exist_ok=True)
+    record = {
+        "schedule_id": schedule_id,
+        "timestamp": datetime.utcnow().isoformat(),
+        "status": status,
+        "symbol": cfg.symbol,
+        "htf": cfg.htf,
+        "ltf": cfg.ltf,
+        "window": {"start": window.start, "end": window.end},
+        "kpi": kpi,
+        "report_path": report_path,
+        "run_id": run_id,
+        "artifacts_root": str(run_dir),
+        "scheduler_root": str(sched_root),
+    }
+
+    with (sched_root / "runs.jsonl").open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(record) + "\n")
+    with (sched_root / "last_status.json").open("w", encoding="utf-8") as fh:
+        json.dump(record, fh, indent=2)
+
+    policy = cfg.notify.get("on", []) if cfg.notify else []
+    if "always" in policy or status in policy:
+        card = fmt_summary_card(record)
+        for name, ch in (cfg.notify.get("channels") or {}).items():
+            if not ch.get("enabled"):
+                continue
+            try:
+                if name == "slack":
+                    url = os.getenv(ch.get("webhook_env", ""))
+                    if not url:
+                        logger.warning("missing env %s for slack", ch.get("webhook_env"))
+                        continue
+                    notify_slack(url, card)
+                elif name == "telegram":
+                    token = os.getenv(ch.get("bot_token_env", ""))
+                    chat_id = os.getenv(ch.get("chat_id_env", ""))
+                    if not token or not chat_id:
+                        logger.warning("missing env for telegram")
+                        continue
+                    notify_telegram(token, chat_id, card)
+                elif name == "email":
+                    smtp = os.getenv(ch.get("smtp_env", ""))
+                    if not smtp:
+                        logger.warning("missing env %s for email", ch.get("smtp_env"))
+                        continue
+                    to = ch.get("to", [])
+                    notify_email(smtp, to, card)
+            except Exception as exc:  # pragma: no cover - external failures
+                logger.warning("notify %s failed: %s", name, exc)
+
+    keep = int(cfg.retention.get("runs_to_keep", 0)) if cfg.retention else 0
+    if keep:
+        cleanup_runs(schedule_id, str(run_dir.parent), keep, bool(cfg.retention.get("delete_old_artifacts", False)))
+
+    return record
+
+
+def start_scheduler(all_cfg: Dict[str, ScheduleCfg]) -> None:
+    logger = logging.getLogger("alpha.ops.scheduler")
+    scheds: Dict[str, Dict[str, Any]] = {}
+    for sid, cfg in all_cfg.items():
+        if not cfg.enable:
+            continue
+        tz = cfg.when.get("tz", "UTC")
+        cron = cfg.when.get("cron", "* * * * *")
+        next_time = next_cron_time(cron, tz, datetime.now(ZoneInfo(tz)) - timedelta(minutes=1))
+        scheds[sid] = {"cfg": cfg, "tz": tz, "cron": cron, "next": next_time}
+
+    try:
+        while True:
+            for sid, info in scheds.items():
+                now = datetime.now(ZoneInfo(info["tz"]))
+                if now >= info["next"]:
+                    run_once(sid, info["cfg"])
+                    info["next"] = next_cron_time(info["cron"], info["tz"], info["next"])
+            time.sleep(1)
+    except KeyboardInterrupt:
+        logger.info("scheduler stopped")
+        return

--- a/alpha/ops/utils.py
+++ b/alpha/ops/utils.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+"""Utilities for scheduler: window calculation and cron helpers."""
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
+
+try:  # pragma: no cover - optional dependency
+    from croniter import croniter  # type: ignore
+except Exception:  # pragma: no cover - fallback when croniter missing
+    croniter = None  # type: ignore
+
+
+@dataclass
+class TimeWindow:
+    start: str
+    end: str
+
+
+def build_window(cfg: dict) -> TimeWindow:
+    """Build start/end date window from scheduler config.
+
+    If mode is ``rolling_days`` the window ends at today's UTC date and
+    starts ``days`` back. For ``fixed`` the start/end strings are used as-is.
+    """
+
+    mode = cfg.get("mode", "rolling_days")
+    if mode == "rolling_days":
+        days = int(cfg.get("days", 0))
+        end_dt = datetime.utcnow().date()
+        start_dt = end_dt - timedelta(days=days)
+        return TimeWindow(start=start_dt.isoformat(), end=end_dt.isoformat())
+    if mode == "fixed":
+        return TimeWindow(start=str(cfg.get("start")), end=str(cfg.get("end")))
+    raise ValueError(f"unknown window mode: {mode}")
+
+
+def next_cron_time(cron: str, tz: str, base: datetime | None = None) -> datetime:
+    """Return next run time for ``cron`` in timezone ``tz``.
+
+    Uses ``croniter`` when available; otherwise a very small fallback
+    supporting only ``* * * * *`` (every minute).
+    """
+
+    tzinfo = ZoneInfo(tz)
+    now = base or datetime.now(tzinfo)
+    if croniter is None:
+        # Fallback: assume every minute
+        return (now + timedelta(minutes=1)).replace(second=0, microsecond=0)
+    return croniter(cron, now).get_next(datetime)  # type: ignore[arg-type]

--- a/tests/test_ops_scheduler.py
+++ b/tests/test_ops_scheduler.py
@@ -1,0 +1,161 @@
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from alpha.ops.scheduler import ScheduleCfg, run_once, start_scheduler
+from alpha.ops.retention import cleanup_runs
+import alpha.ops.scheduler as sched_mod
+import alpha.ops.notifiers as notifiers
+
+@pytest.fixture
+def basic_cfg(tmp_path, monkeypatch):
+    monkeypatch.setenv("ALPHA_ARTIFACTS_ROOT", str(tmp_path / "artifacts"))
+    cfg = ScheduleCfg(
+        enable=True,
+        profile="e2e_h1_m1",
+        symbol="EURUSD",
+        htf="H1",
+        ltf="M1",
+        window={"mode": "rolling_days", "days": 1},
+        when={"tz": "UTC", "cron": "* * * * *"},
+        behavior={"force": False, "resume": True, "fail_fast": True, "dry_run": False},
+        backoff={"retries": 2, "initial_s": 0, "max_s": 0, "factor": 1},
+        notify={
+            "on": ["success"],
+            "channels": {"slack": {"enabled": True, "webhook_env": "SLACK_URL"}},
+        },
+        retention={"runs_to_keep": 5, "delete_old_artifacts": False},
+    )
+    return cfg
+
+
+def _prepare_pipeline(monkeypatch, tmp_path, succeed_after=0):
+    calls = {"n": 0}
+
+    def fake_run_pipeline(run_cfg):
+        calls["n"] += 1
+        if calls["n"] <= succeed_after:
+            raise RuntimeError("boom")
+        run_id = f"20200101_00000{calls['n']}"
+        run_dir = Path(run_cfg.io["runs_root"]) / f"{run_cfg.symbol}_{run_cfg.htf}" / run_id
+        run_dir.mkdir(parents=True, exist_ok=True)
+        (run_dir / "manifest.json").write_text("{}")
+        (run_dir / "pipeline.log").write_text("log")
+        (run_dir / "trades_summary.json").write_text(
+            json.dumps({"n_trades": 4, "win_rate": 0.5, "avg_R": 1.2, "maxDD_R": -1.0})
+        )
+        reports_dir = Path(run_cfg.io["artifacts_root"]) / "reports" / f"{run_cfg.symbol}_{run_cfg.htf}"
+        reports_dir.mkdir(parents=True, exist_ok=True)
+        (reports_dir / f"report_{run_id}.html").write_text("<html></html>")
+        return {
+            "status": "ok",
+            "manifest_path": str(run_dir / "manifest.json"),
+            "timings_path": str(run_dir / "timings.json"),
+            "log_path": str(run_dir / "pipeline.log"),
+        }
+
+    monkeypatch.setattr(sched_mod, "run_pipeline", fake_run_pipeline)
+    return calls
+
+
+
+def _stub_cli(monkeypatch):
+    import types, sys
+
+    m = types.ModuleType("matplotlib")
+    m.colors = types.ModuleType("colors")
+    sys.modules["matplotlib"] = m
+    sys.modules["matplotlib.colors"] = m.colors
+    sys.modules["matplotlib.pyplot"] = types.ModuleType("pyplot")
+    j2 = types.ModuleType("jinja2")
+    j2.Environment = object
+    j2.FileSystemLoader = object
+    sys.modules["jinja2"] = j2
+    from alpha.app.cli import schedule_run
+    return schedule_run
+def test_schedule_run_once(tmp_path, monkeypatch, basic_cfg):
+    schedule_run = _stub_cli(monkeypatch)
+    calls = _prepare_pipeline(monkeypatch, tmp_path)
+    sent = []
+    monkeypatch.setenv("SLACK_URL", "http://example.com")
+    monkeypatch.setattr(notifiers, "notify_slack", lambda url, card: sent.append(url))
+    monkeypatch.setattr(sched_mod, 'notify_slack', lambda url, card: sent.append(url))
+
+    sched_yaml = tmp_path / "scheduler.yml"
+    sched_yaml.write_text(yaml.safe_dump({"schedules": {"job": basic_cfg.__dict__}}))
+
+    schedule_run(profile="e2e_h1_m1", once=True, config_path=str(sched_yaml))
+    assert sent and calls["n"] == 1
+    sched_root = tmp_path / "artifacts" / "scheduler" / "job"
+    assert (sched_root / "runs.jsonl").exists()
+    assert (sched_root / "last_status.json").exists()
+
+
+def test_backoff(tmp_path, monkeypatch, basic_cfg):
+    calls = _prepare_pipeline(monkeypatch, tmp_path, succeed_after=2)
+    monkeypatch.setenv("SLACK_URL", "http://example.com")
+    monkeypatch.setattr(notifiers, "notify_slack", lambda *a, **k: None)
+    run_once("job", basic_cfg)
+    assert calls["n"] == 3
+
+
+def test_retention(tmp_path):
+    runs_root = tmp_path / "runs"
+    for i in range(25):
+        (runs_root / f"r{i:02d}").mkdir(parents=True)
+    result = cleanup_runs("job", str(runs_root), keep_last=20, delete_artifacts=False)
+    assert len(result["kept"]) == 20
+    assert len(result["deleted"]) == 5
+    assert len(list(runs_root.iterdir())) == 20
+
+
+def test_missing_env(monkeypatch, tmp_path, basic_cfg, caplog):
+    _prepare_pipeline(monkeypatch, tmp_path)
+    monkeypatch.delenv("SLACK_URL", raising=False)
+    called = []
+    monkeypatch.setattr(notifiers, "notify_slack", lambda *a, **k: called.append(1))
+    with caplog.at_level("WARNING"):
+        run_once("job", basic_cfg)
+    assert not called
+    assert "missing env" in caplog.text
+
+
+def test_list_schedules(tmp_path, capfd, basic_cfg):
+    schedule_run = _stub_cli(None)
+    sched_yaml = tmp_path / "scheduler.yml"
+    other = basic_cfg.__dict__.copy()
+    other["enable"] = False
+    sched_yaml.write_text(
+        yaml.safe_dump({"schedules": {"job": basic_cfg.__dict__, "job2": other}})
+    )
+    schedule_run(list_schedules=True, config_path=str(sched_yaml))
+    out = capfd.readouterr().out
+    assert "job: enabled" in out
+    assert "job2: disabled" in out
+
+
+def test_start_scheduler(monkeypatch):
+    calls = []
+
+    def fake_run_once(sid, cfg):
+        calls.append(sid)
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(sched_mod, "run_once", fake_run_once)
+    cfg = ScheduleCfg(
+        enable=True,
+        profile="e2e_h1_m1",
+        symbol="EURUSD",
+        htf="H1",
+        ltf="M1",
+        window={"mode": "rolling_days", "days": 1},
+        when={"tz": "UTC", "cron": "* * * * *"},
+        behavior={},
+        backoff={},
+        notify={"on": [], "channels": {}},
+        retention={},
+    )
+    start_scheduler({"job": cfg})
+    assert calls == ["job"]


### PR DESCRIPTION
## Summary
- add modular scheduler to execute pipeline profiles on cron schedules with backoff
- send Slack/Telegram/email notifications via new notifiers
- expose `schedule-run` CLI command and retention utilities

## Testing
- `pytest tests/test_ops_scheduler.py`

------
https://chatgpt.com/codex/tasks/task_e_68aee3789c2883249bf71915e75fcd92